### PR TITLE
Add URIs to RabbitMQ credentials

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -5,3 +5,5 @@ credentials:
   hosts:    (( grab jobs.node.ips ))
   username: (( grab meta.username ))
   password: (( grab meta.password ))
+  uris:     (( cartesian-product "amqp://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.rmq_port ))
+  uri:      (( grab credentials.uris[0] ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -5,3 +5,4 @@ credentials:
   host:     (( grab jobs.standalone/0.ips[0] ))
   username: (( grab meta.username ))
   password: (( grab meta.password ))
+  uri:      (( concat "amqp://" meta.username ":" meta.password "@" jobs.standalone/0.ips[0] ":" credentials.rmq_port ))


### PR DESCRIPTION
Fixes #2, by following the docs here:
https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html#_rabbitmq