### PR TITLE
Correct default network from redis-service to rabbitmq-service

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/bin/configure-blacksmith
+++ b/jobs/rabbitmq-blacksmith-plans/templates/bin/configure-blacksmith
@@ -38,7 +38,7 @@ cat > $PLANROOT/params.yml <<EOF
 # for plan-id <%= id %> (<%= plan["name"] || id %>)
 meta:
   size: <%= plan["vm_type"] || 'default' %>
-  net:  <%= plan["network"] || 'redis-service' %>
+  net:  <%= plan["network"] || 'rabbitmq-service' %>
 
 <% if plan["instances"] && plan["instances"] > 1 %>
   instances: <%= plan["instances"] %>


### PR DESCRIPTION
Current default puts it in redis-services instead