### PR TITLE
Updating Erlang and RabbitMQ versions to 22.3 and 3.7.28

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,8 +1,8 @@
-erlang/otp_src_21.3.tar.gz:
-  size: 85547038
-  object_id: b7579213-ec7a-4987-5c5c-336e2079ce3d
-  sha: sha256:69a743c4f23b2243e06170b1937558122142e47c8ebe652be143199bfafad6e4
-rabbitmq/rabbitmq-server-generic-unix-3.7.23.tar.xz:
-  size: 10031964
-  object_id: 066fdf55-78e2-4ad2-742e-26c315f604ec
-  sha: sha256:b6a658b72aa0f5599b0bb5ec4de22f985e4b88c05669114b6044281430e5dcc8
+erlang/otp_src_22.3.tar.gz:
+  size: 87930432
+  object_id: 01fa974c-19a3-4558-6d5a-066d9ad57f40
+  sha: sha256:5c35b952808fa933ca95a9d259818aee27cb17ca96067da0fda2f035259ee612
+rabbitmq/rabbitmq-server-generic-unix-3.7.28.tar.xz:
+  size: 10229948
+  object_id: 330d3335-fcc5-438a-47e8-4b323ae1861e
+  sha: sha256:8cc45ef421323b407eda3fa82975fffd81d9a46235f6314e16855caedacd02cc

--- a/jobs/rabbitmq/templates/bin/ctl
+++ b/jobs/rabbitmq/templates/bin/ctl
@@ -9,6 +9,12 @@ source /var/vcap/jobs/rabbitmq/helpers/ctl_setup.sh 'rabbitmq'
 case $1 in
 
   start)
+    # We cannot use rabbitmqctl to check the version before the service starts so pulling from the app source
+    grep vsn /var/vcap/packages/*/ebin/rabbit.app | sed -e 's/.*vsn,."\([^ ]*\)".*/\1/' >/var/vcap/store/rabbitmq/RABBITMQ_VERSION
+
+    erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()' >/var/vcap/store/rabbitmq/ERLANG_VERSION_FULL
+    chown vcap:vcap /var/vcap/store/rabbitmq/RABBITMQ_VERSION /var/vcap/store/rabbitmq/ERLANG_VERSION_FULL
+
     <% if p('management') %>
       rabbitmq-plugins enable --offline rabbitmq_management >>$LOG_DIR/$JOB_NAME.log
     <% end %>

--- a/packages/erlang/packaging
+++ b/packages/erlang/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-VERSION=21.3
+VERSION=22.3
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
 tar xfv erlang/otp_src_${VERSION}.tar.gz

--- a/packages/rabbitmq/packaging
+++ b/packages/rabbitmq/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-VERSION=3.7.23
+VERSION=3.7.28
 
 tar -xf $BOSH_COMPILE_TARGET/rabbitmq/rabbitmq-server-generic-unix-${VERSION}.tar.xz
 mv rabbitmq_server-${VERSION}/* $BOSH_INSTALL_TARGET


### PR DESCRIPTION
Updating packages to Erlang 22.3 and  RabbitMQ 3.7.28

Added ERLANG_VERSION_FULL and RABBITMQ_VERSION files to track the last run RabbitMQ version