### PR TITLE
Add ip_address to links

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Improvements
+
+* Set BOSH to use IP addresses for IaaS's that have issues
+

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -36,3 +36,7 @@ instance_groups:
         properties:
           default_user:     (( grab meta.username ))
           default_password: (( grab meta.password ))
+        provides:
+          rabbitmq-servers: { as: rabbitmq-servers,   ip_addresses: true }
+        consumes:
+          rabbitmq-servers: { from: rabbitmq-servers, ip_addresses: true }

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -33,3 +33,7 @@ instance_groups:
         properties:
           default_user:     (( grab meta.username ))
           default_password: (( grab meta.password ))
+        provides:
+          rabbitmq-servers: { as: rabbitmq-servers,   ip_addresses: true }
+        consumes:
+          rabbitmq-servers: { from: rabbitmq-servers, ip_addresses: true }


### PR DESCRIPTION
Some environments were returning BOSH domain names in configs which confused RabbitMQ.  This tells BOSH to always use IP addresses