### PR TITLE
added dynamic backed by default rabbitmq network infromation

### DIFF
--- a/jobs/rabbitmq/spec
+++ b/jobs/rabbitmq/spec
@@ -44,6 +44,9 @@ properties:
     description: The Server Certificate
   rabbitmq.tls.key:
     description: The Server Key
+  rabbitmq.network:
+    description: The network rabbitmq instances are deployed in
+    default: rabbitmq-service
 
   rabbitmq.admin.user:
     description: "Rabbitmq admin username"

--- a/jobs/rabbitmq/templates/env.rb
+++ b/jobs/rabbitmq/templates/env.rb
@@ -14,7 +14,7 @@ export RABBITMQ_ADMIN_USER="<%= p('rabbitmq.admin.user') %>"
 export RABBITMQ_CONFIG_FILE=${JOB_DIR}/config/rabbitmq.conf
 export RABBITMQ_LOG_BASE=${LOG_DIR}
 export RABBITMQ_MNESIA_BASE=/var/vcap/store/rabbitmq
-export RABBITMQ_NODENAME="rabbit@<%= spec.id %>.<%= spec.name %>.blacksmith.<%= spec.deployment %>.bosh"
+export RABBITMQ_NODENAME="rabbit@<%= spec.id %>.<%= spec.name %>.<%= p('rabbitmq.network') %>.<%= spec.deployment %>.bosh"
 export RABBITMQ_PID_FILE="${RUN_DIR}/rabbitmq.pid"
 export RABBITMQ_USE_LONGNAME="true"
 export RABBITMQ_VHOST="/"


### PR DESCRIPTION
Rabbitmq control [script](jobs/rabbitmq/templates/bin/ctl) uses `/var/vcap/jobs/rabbitmq/env` for its environment variables. 
This is populated by the [env.rb](jobs/rabbitmq/templates/env.rb) and until now it had the network part hardcoded to `blacksmith`.
This essentially means that unless the service is indeed deployed under a network named `blacksmith`, rabbitmq start will fail with the following nxdomain error:
```
09:56:34.297 [error] BOOT FAILED
BOOT FAILED
09:56:34.298 [error] ===========
===========
09:56:34.298 [error] ERROR: epmd error for host a97c0f54-a6c4-40f2-87a1-c323b03d78cd.standalone.blacksmith.rabbitmq-standalone-fa37ea67-7927-4076-af1c-d14817e6869e.bosh: nxdomain (non-existing domain)
ERROR: epmd error for host a97c0f54-a6c4-40f2-87a1-c323b03d78cd.standalone.blacksmith.rabbitmq-standalone-fa37ea67-7927-4076-af1c-d14817e6869e.bosh: nxdomain (non-existing domain)
```

The suggested change creates a new spec parameter named `rabbitmq.network` and provides a default value of `rabbitmq-service` since as per the [README](README.md) _By default, VMs will be deployed into a network named `rabbitmq-service`_.
It then feeds the `<%= p('rabbitmq.network') %>` parameter to the [env.rb](jobs/rabbitmq/templates/env.rb) which in turn populates the correct value to `/var/vcap/jobs/rabbitmq/env` and allows for a successful start:

```
  ##  ##      RabbitMQ 3.8.28
  ##  ##
  ##########  Copyright (c) 2007-2022 VMware, Inc. or its affiliates.
  ######  ##
  ##########  Licensed under the MPL 2.0. Website: https://rabbitmq.com

  Erlang:      23.3.4.9 [emu]
  TLS Library: OpenSSL - OpenSSL 1.1.1  11 Sep 2018

  Doc guides:  https://rabbitmq.com/documentation.html
  Support:     https://rabbitmq.com/contact.html
  Tutorials:   https://rabbitmq.com/getstarted.html
  Monitoring:  https://rabbitmq.com/monitoring.html

  Logs: /var/vcap/sys/log/rabbitmq/rabbit@a97c0f54-a6c4-40f2-87a1-c323b03d78cd.standalone.rabbitmq-service.rabbitmq-standalone-fa37ea67-7927-4076-af1c-d14817e6869e.bosh.log
        /var/vcap/sys/log/rabbitmq/rabbit@a97c0f54-a6c4-40f2-87a1-c323b03d78cd.standalone.rabbitmq-service.rabbitmq-standalone-fa37ea67-7927-4076-af1c-d14817e6869e.bosh_upgrade.log

  Config file(s): /var/vcap/jobs/rabbitmq/config/rabbitmq.conf

  Starting broker... completed with 3 plugins.
  ```