### PR TITLE
Add autoscaling metrics based on queue depth

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,6 +1,8 @@
 erlang/otp_src_23.3.4.9.tar.gz:
   size: 99280005
+  object_id: 41803acc-0044-44b7-6b7b-b37c44ab84d3
   sha: sha256:2a2a6538c25736bda659af647ea2aac10eeeabc26c889e051487507045a24581
 rabbitmq/rabbitmq-server-generic-unix-3.8.28.tar.xz:
   size: 15733580
+  object_id: 6ab35d53-1c21-419b-5d5f-7f07b77513c4
   sha: sha256:3beff71ca211be0ee4042b31807d13f299a5a4a1ea6ca023d3808b8aad02c743

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,8 +1,6 @@
 erlang/otp_src_23.3.4.9.tar.gz:
   size: 99280005
-  object_id: 41803acc-0044-44b7-6b7b-b37c44ab84d3
   sha: sha256:2a2a6538c25736bda659af647ea2aac10eeeabc26c889e051487507045a24581
 rabbitmq/rabbitmq-server-generic-unix-3.8.28.tar.xz:
   size: 15733580
-  object_id: 6ab35d53-1c21-419b-5d5f-7f07b77513c4
   sha: sha256:3beff71ca211be0ee4042b31807d13f299a5a4a1ea6ca023d3808b8aad02c743

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,6 +1,6 @@
 ---
 blobstore:
-  provider: local
+  provider: s3
   options:
-    blobstore_path: /Users/ioannis/sw/re/forks/rabbitmq-forge-boshrelease/blobs
+    bucket_name: rabbitmq-forge-boshrelease
 final_name: rabbitmq-forge

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,6 +1,6 @@
 ---
 blobstore:
-  provider: s3
+  provider: local
   options:
-    bucket_name: rabbitmq-forge-boshrelease
+    blobstore_path: /Users/ioannis/sw/re/forks/rabbitmq-forge-boshrelease/blobs
 final_name: rabbitmq-forge

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -22,7 +22,6 @@ templates:
   tls/loggregator.ca:               tls/loggregator.ca
   tls/loggregator.crt:              tls/loggregator.crt
   tls/loggregator.key:              tls/loggregator.key
-  tls/blacksmith_rabbitmq_services.ca:  tls/blacksmith_rabbitmq_services.ca
 
 properties:
   service.id:
@@ -112,9 +111,6 @@ properties:
   rabbitmq_metrics_emitter.rmq_management.mgmt_host:
     description: The hostname used when connecting to the rabbitmq api
     default: localhost
-
-  blacksmith_rabbitmq_services.tls.ca_cert:
-    description: PEM encoded CA certificate provided by blacksmith
 
   rabbitmq.tls.enabled:
     description: "Use TLS"

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -73,15 +73,6 @@ properties:
   
   loggregator.tls.agent.key:
     description: The private key for loggregator agent
-  
-  metrics.ca_cert:
-    description: The CA Certificate for the metrics emitter
-
-  metrics.cert:
-    description: The Certificate for metrics emitter
-  
-  metrics.key:
-    description: The private key for metrics emitter
 
   rabbitmq_metrics_emitter.cloud_foundry.api:
     description: url of the cf api (same as cf.api_url above)

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -20,8 +20,9 @@ templates:
   tls/rabbitmq.key.erb:             tls/rabbitmq.key
   tls/rabbitmq.crt.erb:             tls/rabbitmq.crt
   tls/loggregator.ca:               tls/loggregator.ca
-  tls/loggregator.crt:               tls/loggregator.crt
-  tls/loggregator.key:               tls/loggregator.key
+  tls/loggregator.crt:              tls/loggregator.crt
+  tls/loggregator.key:              tls/loggregator.key
+  tls/blacksmith_rabbitmq_services.ca:  tls/blacksmith_rabbitmq_services.ca
 
 properties:
   service.id:
@@ -99,6 +100,9 @@ properties:
   rabbitmq_metrics_emitter.rmq_management.skip_ssl_validation:
     description: Skip ssl validation when contacting the rabbitmq api
     default: true
+  
+  blacksmith_rabbitmq_services.tls.ca_cert:
+    description: PEM encoded CA certificate provided by blacksmith
 
   rabbitmq.tls.enabled:
     description: "Use TLS"

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -62,6 +62,36 @@ properties:
   cf.password:
     description: The admin password for cloudfoundry
 
+  loggregator.tls.ca_cert:
+    description: The CA Certificate for loggregator
+  
+  loggregator.tls.ca_cert.agent.cert:
+    description: The Certificate for loggregator agent
+  
+  loggregator.tls.ca_cert.agent.key:
+    description: The private key for loggregator agent
+  
+  metrics.ca_cert:
+    description: The CA Certificate for the metrics emitter
+
+  metrics.cert:
+    description: The Certificate for metrics emitter
+  
+  metrics.key:
+    description: The private key for metrics emitter
+
+  rabbitmq_metrics_emitter.cloud_foundry.api:
+    description: url of the cf api (same as cf.api_url above)
+
+  rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation:
+    description: Skip ssl validation when contacting the api
+
+  rabbitmq_metrics_emitter.cloud_foundry.username:
+    description: The admin username for cloudfoundry (same as cf.username above)
+
+  rabbitmq_metrics_emitter.cloud_foundry.password:
+    description: The admin password for cloudfoundry (same as cf.password above)
+
   rabbitmq.tls.enabled:
     description: "Use TLS"
     default: false
@@ -69,7 +99,7 @@ properties:
     description: "Allow for TLS (5671) and Non-TLS (5672) both."
     default: true
   rabbitmq.tls.ca:
-    description: The CA Sertificate for the Server Certificate
+    description: The CA Certificate for the Server Certificate
   rabbitmq.tls.crt:
     description: The Server Certificate
   rabbitmq.tls.key:

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -65,10 +65,10 @@ properties:
   loggregator.tls.ca_cert:
     description: The CA Certificate for loggregator
   
-  loggregator.tls.ca_cert.agent.cert:
+  loggregator.tls.agent.cert:
     description: The Certificate for loggregator agent
   
-  loggregator.tls.ca_cert.agent.key:
+  loggregator.tls.agent.key:
     description: The private key for loggregator agent
   
   metrics.ca_cert:

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -101,6 +101,18 @@ properties:
     description: Skip ssl validation when contacting the rabbitmq api
     default: true
   
+  rabbitmq_metrics_emitter.rmq_management.mgmt_port:
+    description: The port used when connecting to the rabbitmq api
+    default: 15671
+
+  rabbitmq_metrics_emitter.rmq_management.mgmt_scheme:
+    description: The scheme used when connecting to the rabbitmq api
+    default: https
+
+  rabbitmq_metrics_emitter.rmq_management.mgmt_host:
+    description: The hostname used when connecting to the rabbitmq api
+    default: localhost
+
   blacksmith_rabbitmq_services.tls.ca_cert:
     description: PEM encoded CA certificate provided by blacksmith
 

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -6,6 +6,7 @@ templates:
   bin/configure-blacksmith: bin/configure-blacksmith
 
   plans/service.yml:                plans/service.yml
+  plans/meta.yml:                   plans/meta.yml
 
   plans/standalone/manifest.yml:    plans/standalone/manifest.yml
   plans/standalone/credentials.yml: plans/standalone/credentials.yml
@@ -39,6 +40,27 @@ properties:
   service.limit:
     description: A global limit on the number of RabbitMQ services (regardless of the plan); 0 = unlimited.
     default: 0
+  
+  environment:
+    description: The environment name of the cloudfoundry/bosh deployment
+
+  cf.exodus_path:
+    description: The vault path pointing to the cf deployment
+
+  cf.deployment_name:
+    description: The cloudfoundry deployment name
+  
+  cf.system_domain:
+    description: The top level cloudfoundry domain
+
+  cf.api_url:
+    description: url of the cf api
+
+  cf.username:
+    description: The admin username for cloudfoundry
+
+  cf.password:
+    description: The admin password for cloudfoundry
 
   rabbitmq.tls.enabled:
     description: "Use TLS"

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -87,13 +87,18 @@ properties:
     description: url of the cf api (same as cf.api_url above)
 
   rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation:
-    description: Skip ssl validation when contacting the api
+    description: Skip ssl validation when contacting the cf api
+    default: true
 
   rabbitmq_metrics_emitter.cloud_foundry.username:
     description: The admin username for cloudfoundry (same as cf.username above)
 
   rabbitmq_metrics_emitter.cloud_foundry.password:
     description: The admin password for cloudfoundry (same as cf.password above)
+  
+  rabbitmq_metrics_emitter.rmq_management.skip_ssl_validation:
+    description: Skip ssl validation when contacting the rabbitmq api
+    default: true
 
   rabbitmq.tls.enabled:
     description: "Use TLS"

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -19,6 +19,9 @@ templates:
   tls/rabbitmq.ca.erb:              tls/rabbitmq.ca
   tls/rabbitmq.key.erb:             tls/rabbitmq.key
   tls/rabbitmq.crt.erb:             tls/rabbitmq.crt
+  tls/loggregator.ca:               tls/loggregator.ca
+  tls/loggregator.crt:               tls/loggregator.crt
+  tls/loggregator.key:               tls/loggregator.key
 
 properties:
   service.id:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -6,7 +6,7 @@ credentials:
   mgmt_port:     15672
   tls_mgmt_port: 15671
   hosts:         (( grab jobs.node.ips ))
-  vhost:         (( grab params.instance_id || "/" ))
+  vhost:         (( grab meta.vhost || "/" ))
   username:      (( grab meta.username ))
   password:      (( grab meta.password ))
   uris:          (( cartesian-product "amqp://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.rmq_port ))
@@ -19,7 +19,7 @@ credentials:
       password:  (( grab meta.password ))
       hosts:     (( grab jobs.node.ips ))
       host:      (( grab credentials.hosts[0] ))
-      vhost:         (( grab params.instance_id || "/" ))
+      vhost:     (( grab meta.vhost || "/" ))
       port: 5672
       ssl: false
       uris:      (( grab credentials.uris ))
@@ -29,7 +29,7 @@ credentials:
       password:  (( grab meta.password ))
       host:      (( grab jobs.node.ips[0] ))
       port: 5671
-      vhost:         (( grab params.instance_id || "/" ))
+      vhost:     (( grab meta.vhost || "/" ))
       uris:      (( cartesian-product "amqps://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -1,6 +1,4 @@
 ---
-meta:
-  vhost: f680fee2-cd83-4f4b-a24f-a91ceb05fbe9
 credentials:
   dashboard_url: ((  concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
   rmq_port:      5672
@@ -8,7 +6,7 @@ credentials:
   mgmt_port:     15672
   tls_mgmt_port: 15671
   hosts:         (( grab jobs.node.ips ))
-  vhost:         (( grab meta.vhost || "/" ))
+  vhost: "/"
   username:      (( grab meta.username ))
   password:      (( grab meta.password ))
   uris:          (( cartesian-product "amqp://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.rmq_port ))
@@ -21,7 +19,7 @@ credentials:
       password:  (( grab meta.password ))
       hosts:     (( grab jobs.node.ips ))
       host:      (( grab credentials.hosts[0] ))
-      vhost:     (( grab meta.vhost || "/" ))
+      vhost: "/"
       port: 5672
       ssl: false
       uris:      (( grab credentials.uris ))
@@ -31,7 +29,7 @@ credentials:
       password:  (( grab meta.password ))
       host:      (( grab jobs.node.ips[0] ))
       port: 5671
-      vhost:     (( grab meta.vhost || "/" ))
+      vhost: "/"
       uris:      (( cartesian-product "amqps://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -1,4 +1,6 @@
 ---
+meta:
+  vhost: f680fee2-cd83-4f4b-a24f-a91ceb05fbe9
 credentials:
   dashboard_url: ((  concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
   rmq_port:      5672

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -6,7 +6,7 @@ credentials:
   mgmt_port:     15672
   tls_mgmt_port: 15671
   hosts:         (( grab jobs.node.ips ))
-  vhost: "/"
+  vhost:         (( grab params.instance_id || "/" ))
   username:      (( grab meta.username ))
   password:      (( grab meta.password ))
   uris:          (( cartesian-product "amqp://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.rmq_port ))
@@ -19,7 +19,7 @@ credentials:
       password:  (( grab meta.password ))
       hosts:     (( grab jobs.node.ips ))
       host:      (( grab credentials.hosts[0] ))
-      vhost: "/"
+      vhost:         (( grab params.instance_id || "/" ))
       port: 5672
       ssl: false
       uris:      (( grab credentials.uris ))
@@ -29,7 +29,7 @@ credentials:
       password:  (( grab meta.password ))
       host:      (( grab jobs.node.ips[0] ))
       port: 5671
-      vhost: "/"
+      vhost:         (( grab params.instance_id || "/" ))
       uris:      (( cartesian-product "amqps://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/meta.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/meta.yml
@@ -1,0 +1,11 @@
+---
+meta:
+  environment: <%= p('p.environment') %>
+
+  cf:
+    exodus_path: <%= p('p.cf.exodus_path') %>
+    deployment_name: <%= p('p.cf.deployment_name') %>
+    system_domain: <%= p('p.cf.system_domain') %>
+    api_url:    <%= p('p.cf.api_url') %>
+    username:   <%= p('p.cf.username') %>
+    password:   <%= p('p.cf.password') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/meta.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/meta.yml
@@ -1,11 +1,11 @@
 ---
 meta:
-  environment: <%= p('p.environment') %>
+  environment: <%= p('environment') %>
 
   cf:
-    exodus_path: <%= p('p.cf.exodus_path') %>
-    deployment_name: <%= p('p.cf.deployment_name') %>
-    system_domain: <%= p('p.cf.system_domain') %>
-    api_url:    <%= p('p.cf.api_url') %>
-    username:   <%= p('p.cf.username') %>
-    password:   <%= p('p.cf.password') %>
+    exodus_path: <%= p('cf.exodus_path') %>
+    deployment_name: <%= p('cf.deployment_name') %>
+    system_domain: <%= p('cf.system_domain') %>
+    api_url:    <%= p('cf.api_url') %>
+    username:   <%= p('cf.username') %>
+    password:   <%= p('cf.password') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -32,7 +32,7 @@ variables:
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
-    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/" blacksmith_rabbitmq_services_ca ))
+    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_rabbitmq_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
   consumes:
     common_name:
@@ -43,7 +43,7 @@ variables:
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
-    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/" blacksmith_rabbitmq_services_ca ))
+    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_rabbitmq_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
   consumes:
     common_name:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -43,13 +43,12 @@ variables:
   type: certificate
   options:
     is_ca: true
-    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh-internal" ))
-    alternative_names: localhost
+    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
     ca: rabbitmq_standalone_ca
-    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh-internal" ))
+    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
     alternative_names: localhost
 
 features:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -190,7 +190,7 @@ addons:
         release: rabbitmq-forge
         properties:
           rabbitmq:
-            vhost: f680fee2-cd83-4f4b-a24f-a91ceb05fbe9
+            vhost: (( grab meta.vhost ))
             default:
               user: rabbit
               password: (( grab meta.password ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -113,19 +113,33 @@ instance_groups:
         tls:
           enabled: (( grab meta.rabbitmq.tls.enabled || false ))
           dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
-          ca: (( grab meta.rabbitmq.tls.ca || "" ))
-          crt: (( grab meta.rabbitmq.tls.crt || "" ))
-          key: (( grab meta.rabbitmq.tls.key || "" ))
+          ca: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
+          crt: ((rabbitmq_standalone_crt.certificate))
+          key: ((rabbitmq_standalone_crt.private_key))
 
     provides:
       rabbitmq-servers:
         as: rabbitmq-servers
         ip_addresses: false
-
+      rabbitmq-san:
+        as: rabbitmq-san
+        ip_addresses: false
+      rabbitmq-alias-domain:
+        aliases:
+        - domain: "_.rabbitmq_standalone.bosh"
+          placeholder_type: uuid
     consumes:
       rabbitmq-servers:
         from: rabbitmq-servers
         ip_addresses: false
+    custom_provider_definitions:
+    - name: rabbitmq-san  
+        - name: rabbitmq-san  
+    - name: rabbitmq-san  
+      type: address
+    - name: rabbitmq-alias-domain
+      type: placeholder
+
 
 <% if p("rabbitmq.route_registrar.enabled") -%>
   - name: route_registrar
@@ -186,91 +200,53 @@ addons:
           network: (( grab params.cf.core_network ))
           query: _
 <% end %>
-      - name:    rabbitmq
-        release: rabbitmq-forge
-        properties:
-          rabbitmq:
-            vhost: (( grab meta.params.instance_id || "/" ))
-            default:
-              user: rabbit
-              password: (( grab meta.password ))
-            admin:
-              user: (( grab meta.username ))
-              pass: (( grab meta.password ))
-            tls:
-              enabled: (( grab meta.rabbitmq.tls.enabled || false ))
-              dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
-              ca: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
-              crt: ((rabbitmq_standalone_crt.certificate))
-              key: ((rabbitmq_standalone_crt.private_key))
 
-        provides:
-          rabbitmq-servers:
-            as: rabbitmq-servers
-            ip_addresses: false
-          rabbitmq-san:
-            as: rabbitmq-san
-            ip_addresses: false
-          rabbitmq-alias-domain:
-            aliases:
-            - domain: "_.rabbitmq_standalone.bosh"
-              placeholder_type: uuid
-        consumes:
-          rabbitmq-servers:
-            from: rabbitmq-servers
-            ip_addresses: false
-        custom_provider_definitions:
-        - name: rabbitmq-san  
-          type: address
-        - name: rabbitmq-alias-domain
-          type: placeholder
+  - name:    bpm
+    release: bpm
 
-      - name:    bpm
-        release: bpm
+  - name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler:
+        from: doppler
+        deployment: (( grab meta.cf.deployment_name ))
+    properties:
+      loggregator:
+        tls:
+          ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+          agent:
+            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+      metrics:
+        server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
+        ca_cert: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
+        cert:    ((rabbitmq_metrics_emitter_crt.certificate))
+        key:     ((rabbitmq_metrics_emitter_crt.private_key))
 
-      - name: loggregator_agent
-        release: loggregator-agent
-        consumes:
-          doppler:
-            from: doppler
-            deployment: (( grab meta.cf.deployment_name ))
-        properties:
-          loggregator:
-            tls:
-              ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
-              agent:
-                cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
-                key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
-          metrics:
-            server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
-            cert:    ((rabbitmq_metrics_emitter_crt.certificate))
-            key:     ((rabbitmq_metrics_emitter_crt.private_key))
+  - name: rabbitmq-metrics-emitter
+    release: rabbitmq-metrics-emitter
+    properties:
+      rabbitmq_metrics_emitter:
+        cloud_foundry:
+          api:    (( grab meta.cf.api_url ))
+          skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation') %>
+          username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
+          password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
+        rmq_management:
+          skip_ssl_validation: (( grab meta.mgmt_ssl ))
+          endpoint: (( concat meta.mgmt_scheme "://" meta.mgmt_host ":" meta.mgmt_port "/api" ))
+          user: (( grab meta.username ))
+          password: (( grab meta.password ))
+        loggregator:
+          tls:
+            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+            ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
 
-      - name: rabbitmq-metrics-emitter
-        release: rabbitmq-metrics-emitter
-        properties:
-          rabbitmq_metrics_emitter:
-            cloud_foundry:
-              api:    (( grab meta.cf.api_url ))
-              skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation') %>
-              username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
-              password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
-            rmq_management:
-              skip_ssl_validation: (( grab meta.mgmt_ssl ))
-              endpoint: (( concat meta.mgmt_scheme "://" meta.mgmt_host ":" meta.mgmt_port "/api" ))
-              user: (( grab meta.username ))
-              password: (( grab meta.password ))
-            loggregator:
-              tls:
-                cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
-                key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
-                ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
-
-        provides:
-          rabbitmq-emitter:
-            as: rabbitmq-emitter
-            ip_addresses: false
-        custom_provider_definitions:
-        - name: rabbitmq-emitter
-          type: address
+    provides:
+      rabbitmq-emitter:
+        as: rabbitmq-emitter
+        ip_addresses: false
+    custom_provider_definitions:
+    - name: rabbitmq-emitter
+      type: address

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -134,8 +134,6 @@ instance_groups:
         ip_addresses: false
     custom_provider_definitions:
     - name: rabbitmq-san  
-        - name: rabbitmq-san  
-    - name: rabbitmq-san  
       type: address
     - name: rabbitmq-alias-domain
       type: placeholder

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -219,7 +219,7 @@ addons:
                 key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: ((rabbitmq_metrics_emitter_ca))
+            ca_cert: ((rabbitmq_metrics_emitter_ca.certificate))
             cert:    ((rabbitmq_metrics_emitter_crt.certificate))
             key:     ((rabbitmq_metrics_emitter_crt.private_key))
 

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -24,9 +24,10 @@ params:
     username:   <%= p('cf.username') %>
     password:   <%= p('cf.password') %>
   
-  mgmt_port:   15671
-  mgmt_scheme: https
-  rabbitmq_host: localhost
+  mgmt_ssl:    <%= p('rabbitmq_metrics_emitter.rmq_management.skip_ssl_validation') %>
+  mgmt_port:   <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_port') %>
+  mgmt_scheme: <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_scheme') %>
+  mgmt_host:   <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_host') %>
 
 variables:
 - name: rabbitmq_metrics_emitter_crt
@@ -46,8 +47,6 @@ variables:
     ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_rabbitmq_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
   consumes:
-    common_name:
-      from: rabbitmq-san
     alternative_name: 
       from: rabbitmq-san 
       properties: { wildcard: true }
@@ -211,7 +210,7 @@ addons:
           rabbitmq-san:
             as: rabbitmq-san
             ip_addresses: false
-          my_custom_link:
+          rabbitmq-alias-domain:
             aliases:
             - domain: "_.rabbitmq_standalone.bosh"
               placeholder_type: uuid
@@ -222,6 +221,8 @@ addons:
         custom_provider_definitions:
         - name: rabbitmq-san  
           type: address
+        - name: rabbitmq-alias-domain
+          type: placeholder
 
       - name:    bpm
         release: bpm
@@ -255,8 +256,8 @@ addons:
               username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
               password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
             rmq_management:
-              skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.rmq_management.skip_ssl_validation') %>
-              endpoint: (( concat meta.mgmt_scheme "://" meta.rabbitmq_host ":" meta.mgmt_port "/api" ))
+              skip_ssl_validation: (( grab meta.mgmt_ssl ))
+              endpoint: (( concat meta.mgmt_scheme "://" meta.mgmt_host ":" meta.mgmt_port "/api" ))
               user: (( grab meta.username ))
               password: (( grab meta.password ))
             loggregator:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -14,8 +14,8 @@ params:
      core_network: <%= p("cf.core_network") %>
 <% end -%>
 
-  environment: (( grab genesis.env || params.env ))
-  bosh_exodus_path: (( grab params.bosh_exodus_path || genesis.bosh || params.bosh || genesis.env || params.env ))
+  environment: (( grab params.env ))
+  bosh_exodus_path: (( grab params.env ))
 
   cf:
     exodus_path: (( concat "secret/exodus/" meta.bosh_exodus_path "/cf" ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -190,7 +190,7 @@ addons:
         release: rabbitmq-forge
         properties:
           rabbitmq:
-            vhost: (( grab meta.vhost ))
+            vhost: (( grab meta.params.instance_id || "/" ))
             default:
               user: rabbit
               password: (( grab meta.password ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -243,6 +243,7 @@ addons:
               username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
               password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
             rmq_management:
+              skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.rmq_management.skip_ssl_validation') %>
               endpoint: (( concat meta.mgmt_scheme "://" meta.rabbitmq_host ":" meta.mgmt_port "/api" ))
               user: (( grab meta.username ))
               password: (( grab meta.password ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -16,7 +16,7 @@ params:
 
   environment: <%= p('environment') %>
 
-   cf:
+  cf:
     exodus_path: <%= p('cf.exodus_path') %>
     deployment_name: <%= p('cf.deployment_name') %>
     system_domain: <%= p('cf.system_domain') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -23,6 +23,9 @@ params:
     api_url:    <%= p('cf.api_url') %>
     username:   <%= p('cf.username') %>
     password:   <%= p('cf.password') %>
+  
+  mgmt_port:   15671
+  mgmt_scheme: https
 
 
 features:
@@ -190,15 +193,15 @@ addons:
         properties:
           loggregator:
             tls:
-              ca_cert: (( vault meta.cf.exodus_path ":loggregator_ca" ))
+              ca_cert:  <%= p('loggregator.tls.ca_cert') %>
               agent:
-                cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
-                key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
+                cert: <%= p('loggregator.tls.ca_cert.agent.cert') %>
+                key: <%= p('loggregator.tls.ca_cert.agent.key') %>
           metrics:
-            server_name: (( concat genesis.env "-rabbitmq-metrics-emitter" ))
-            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
-            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
-            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
+            server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
+            ca_cert: <%= p('metrics.ca_cert') %>
+            cert:    <%= p('metrics.cert') %>
+            key:     <%= p('metrics.key') %>
 
       - name: rabbitmq-metrics-emitter
         release: rabbitmq-metrics-emitter
@@ -206,15 +209,15 @@ addons:
           rabbitmq_metrics_emitter:
             cloud_foundry:
               api:    (( grab meta.cf.api_url ))
-              skip_ssl_validation: (( grab params.cf_skip_ssl_validation ))
-              username:   (( vault meta.cf.exodus_path ":admin_username" ))
-              password:   (( vault meta.cf.exodus_path ":admin_password" ))
+              skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation') %>
+              username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
+              password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
             rmq_management:
-              endpoint: (( concat meta.mgmt_scheme "://" params.mgmt_domain ":" meta.mgmt_port "/api" ))
-              user: management
-              password: (( vault meta.vault "/rabbitmq/admin/management:password" ))
+              endpoint: (( concat meta.mgmt_scheme "://" jobs.standalone/0.ips[0] ":" meta.mgmt_port "/api" ))
+              user: (( grab meta.username ))
+              password: (( grab meta.password ))
             loggregator:
               tls:
-                cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
-                key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
-                ca_cert: (( vault meta.cf.exodus_path ":loggregator_ca" ))
+                cert: <%= p('loggregator.tls.ca_cert') %>
+                key: <%= p('loggregator.tls.ca_cert.agent.cert') %>
+                ca_cert: <%= p('loggregator.tls.ca_cert.agent.key') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -27,6 +27,17 @@ params:
   mgmt_port:   15671
   mgmt_scheme: https
 
+variables:
+- name: rabbitmq_metrics_emitter_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
+- name: rabbitmq_metrics_emitter_crt
+  type: certificate
+  options:
+    ca: rabbitmq_metrics_emitter_ca
+    common_name: ((internal_ip))
 
 features:
   use_dns_addresses: true
@@ -199,9 +210,9 @@ addons:
                 key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
-            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
-            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
+            ca_cert: (( rabbitmq_metrics_emitter_ca ))
+            cert:    (( rabbitmq_metrics_emitter_crt.certificate ))
+            key:     (( rabbitmq_metrics_emitter_crt.key ))
 
       - name: rabbitmq-metrics-emitter
         release: rabbitmq-metrics-emitter

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -17,7 +17,7 @@ params:
   environment: (( params.env ))
 
   cf:
-    exodus_path: (( concat "secret/exodus/" params.env "/cf" ))
+    exodus_path: (( concat "secret/exodus/" meta.environment "/cf" ))
     deployment_name: (( concat meta.environment "-cf" ))
     system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
     api_url:    (( concat "https://api." meta.cf.system_domain ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -29,26 +29,28 @@ params:
   rabbitmq_host: localhost
 
 variables:
-- name: rabbitmq_metrics_emitter_ca
-  type: certificate
-  options:
-    is_ca: true
-    common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
-    ca: rabbitmq_metrics_emitter_ca
+    ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
     common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
-- name: rabbitmq_standalone_ca
-  type: certificate
-  options:
-    is_ca: true
-    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
+  consumes:
+    common_name:
+      from: rabbitmq-emitter
+    alternative_name: 
+      from: rabbitmq-emitter
+      properties: { wildcard: true }
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
-    ca: rabbitmq_standalone_ca
+    ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
+  consumes:
+    common_name:
+      from: rabbitmq-san
+    alternative_name: 
+      from: rabbitmq-san 
+      properties: { wildcard: true }
 
 features:
   use_dns_addresses: true
@@ -206,10 +208,20 @@ addons:
           rabbitmq-servers:
             as: rabbitmq-servers
             ip_addresses: false
+          rabbitmq-san:
+            as: rabbitmq-san
+            ip_addresses: false
+          my_custom_link:
+            aliases:
+            - domain: "_.rabbitmq_standalone.bosh"
+              placeholder_type: uuid
         consumes:
           rabbitmq-servers:
             from: rabbitmq-servers
             ip_addresses: false
+        custom_provider_definitions:
+        - name: rabbitmq-san  
+          type: address
 
       - name:    bpm
         release: bpm
@@ -252,3 +264,11 @@ addons:
                 cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
                 key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
                 ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+
+        provides:
+          rabbitmq-emitter:
+            as: rabbitmq-emitter
+            ip_addresses: false
+        custom_provider_definitions:
+        - name: rabbitmq-emitter
+          type: address

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -15,10 +15,9 @@ params:
 <% end -%>
 
   environment: (( grab params.env ))
-  bosh_exodus_path: (( grab params.env ))
 
   cf:
-    exodus_path: (( concat "secret/exodus/" meta.bosh_exodus_path "/cf" ))
+    exodus_path: (( concat "secret/exodus/" grab params.env "/cf" ))
     deployment_name: (( concat meta.environment "-cf" ))
     system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
     api_url:    (( concat "https://api." meta.cf.system_domain ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -14,15 +14,15 @@ params:
      core_network: <%= p("cf.core_network") %>
 <% end -%>
 
-  environment: (( params.env ))
+  environment: <%= p('environment') %>
 
-  cf:
-    exodus_path: (( concat "secret/exodus/" meta.environment "/cf" ))
-    deployment_name: (( concat meta.environment "-cf" ))
-    system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
-    api_url:    (( concat "https://api." meta.cf.system_domain ))
-    username:   (( vault meta.cf.exodus_path ":admin_username" ))
-    password:   (( vault meta.cf.exodus_path ":admin_password" ))
+   cf:
+    exodus_path: <%= p('cf.exodus_path') %>
+    deployment_name: <%= p('cf.deployment_name') %>
+    system_domain: <%= p('cf.system_domain') %>
+    api_url:    <%= p('cf.api_url') %>
+    username:   <%= p('cf.username') %>
+    password:   <%= p('cf.password') %>
 
 
 features:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -193,10 +193,10 @@ addons:
         properties:
           loggregator:
             tls:
-              ca_cert:  <%= p('loggregator.tls.ca_cert') %>
+              ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
               agent:
-                cert: <%= p('loggregator.tls.agent.cert') %>
-                key: <%= p('loggregator.tls.agent.key') %>
+                cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+                key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
             ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
@@ -218,6 +218,6 @@ addons:
               password: (( grab meta.password ))
             loggregator:
               tls:
-                cert: <%= p('loggregator.tls.ca_cert') %>
-                key: <%= p('loggregator.tls.agent.cert') %>
-                ca_cert: <%= p('loggregator.tls.agent.key') %>
+                cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+                key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+                ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -26,7 +26,7 @@ params:
   
   mgmt_port:   15671
   mgmt_scheme: https
-  rabbitmq_host: <%= spec.networks.default.ip %>
+  rabbitmq_host: lab-rabbitmq-metrics-emitter.bosh
 
 variables:
 - name: rabbitmq_metrics_emitter_ca

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -199,9 +199,9 @@ addons:
                 key: <%= p('loggregator.tls.agent.key') %>
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: <%= p('metrics.ca_cert') %>
-            cert:    <%= p('metrics.cert') %>
-            key:     <%= p('metrics.key') %>
+            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
+            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
+            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
 
       - name: rabbitmq-metrics-emitter
         release: rabbitmq-metrics-emitter

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -14,6 +14,18 @@ params:
      core_network: <%= p("cf.core_network") %>
 <% end -%>
 
+  environment: (( grab genesis.env || params.env ))
+  bosh_exodus_path: (( grab params.bosh_exodus_path || genesis.bosh || params.bosh || genesis.env || params.env ))
+
+  cf:
+    exodus_path: (( concat "secret/exodus/" meta.bosh_exodus_path "/cf" ))
+    deployment_name: (( concat meta.environment "-cf" ))
+    system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
+    api_url:    (( concat "https://api." meta.cf.system_domain ))
+    username:   (( vault meta.cf.exodus_path ":admin_username" ))
+    password:   (( vault meta.cf.exodus_path ":admin_password" ))
+
+
 features:
   use_dns_addresses: true
 

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -49,7 +49,6 @@ variables:
   options:
     ca: rabbitmq_standalone_ca
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
-    alternative_names: localhost
 
 features:
   use_dns_addresses: true

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -14,10 +14,10 @@ params:
      core_network: <%= p("cf.core_network") %>
 <% end -%>
 
-  environment: (( grab params.env ))
+  environment: (( params.env ))
 
   cf:
-    exodus_path: (( concat "secret/exodus/" grab params.env "/cf" ))
+    exodus_path: (( concat "secret/exodus/" params.env "/cf" ))
     deployment_name: (( concat meta.environment "-cf" ))
     system_domain: (( vault meta.cf.exodus_path ":system_domain" ))
     api_url:    (( concat "https://api." meta.cf.system_domain ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -195,8 +195,8 @@ addons:
             tls:
               ca_cert:  <%= p('loggregator.tls.ca_cert') %>
               agent:
-                cert: <%= p('loggregator.tls.ca_cert.agent.cert') %>
-                key: <%= p('loggregator.tls.ca_cert.agent.key') %>
+                cert: <%= p('loggregator.tls.agent.cert') %>
+                key: <%= p('loggregator.tls.agent.key') %>
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
             ca_cert: <%= p('metrics.ca_cert') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -33,7 +33,7 @@ variables:
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
-    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_rabbitmq_services_ca" ))
+    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
   consumes:
     common_name:
@@ -44,7 +44,7 @@ variables:
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
-    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_rabbitmq_services_ca" ))
+    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
   consumes:
     alternative_name: 
@@ -200,7 +200,7 @@ addons:
             tls:
               enabled: (( grab meta.rabbitmq.tls.enabled || false ))
               dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
-              ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
+              ca: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
               crt: ((rabbitmq_standalone_crt.certificate))
               key: ((rabbitmq_standalone_crt.private_key))
 
@@ -243,7 +243,7 @@ addons:
                 key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
+            ca_cert: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
             cert:    ((rabbitmq_metrics_emitter_crt.certificate))
             key:     ((rabbitmq_metrics_emitter_crt.private_key))
 

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -219,5 +219,5 @@ addons:
             loggregator:
               tls:
                 cert: <%= p('loggregator.tls.ca_cert') %>
-                key: <%= p('loggregator.tls.ca_cert.agent.cert') %>
-                ca_cert: <%= p('loggregator.tls.ca_cert.agent.key') %>
+                key: <%= p('loggregator.tls.agent.cert') %>
+                ca_cert: <%= p('loggregator.tls.agent.key') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -32,7 +32,7 @@ variables:
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
-    ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
+    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/" blacksmith_rabbitmq_services_ca ))
     common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
   consumes:
     common_name:
@@ -43,7 +43,7 @@ variables:
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
-    ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
+    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/" blacksmith_rabbitmq_services_ca ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
   consumes:
     common_name:
@@ -200,7 +200,7 @@ addons:
             tls:
               enabled: (( grab meta.rabbitmq.tls.enabled || false ))
               dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
-              ca: ((rabbitmq_standalone_ca.certificate))
+              ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
               crt: ((rabbitmq_standalone_crt.certificate))
               key: ((rabbitmq_standalone_crt.private_key))
 
@@ -241,7 +241,7 @@ addons:
                 key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: ((rabbitmq_metrics_emitter_ca.certificate))
+            ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/blacksmith_rabbitmq_services.ca" ))
             cert:    ((rabbitmq_metrics_emitter_crt.certificate))
             key:     ((rabbitmq_metrics_emitter_crt.private_key))
 

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -26,7 +26,7 @@ params:
   
   mgmt_port:   15671
   mgmt_scheme: https
-  rabbitmq_host: lab-rabbitmq-metrics-emitter.bosh
+  rabbitmq_host: localhost
 
 variables:
 - name: rabbitmq_metrics_emitter_ca
@@ -39,6 +39,18 @@ variables:
   options:
     ca: rabbitmq_metrics_emitter_ca
     common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
+- name: rabbitmq_standalone_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh-internal" ))
+    alternative_names: localhost
+- name: rabbitmq_standalone_crt
+  type: certificate
+  options:
+    ca: rabbitmq_standalone_ca
+    common_name: (( concat meta.environment "-rabbitmq-standalone.bosh-internal" ))
+    alternative_names: localhost
 
 features:
   use_dns_addresses: true
@@ -188,9 +200,9 @@ addons:
             tls:
               enabled: (( grab meta.rabbitmq.tls.enabled || false ))
               dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
-              ca: (( grab meta.rabbitmq.tls.ca || "" ))
-              crt: (( grab meta.rabbitmq.tls.crt || "" ))
-              key: (( grab meta.rabbitmq.tls.key || "" ))
+              ca: ((rabbitmq_standalone_ca.certificate))
+              crt: ((rabbitmq_standalone_crt.certificate))
+              key: ((rabbitmq_standalone_crt.private_key))
 
         provides:
           rabbitmq-servers:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -25,6 +25,16 @@ releases:
   - { name: bosh-dns-aliases, version: latest}
 <% end -%>
 
+  - name: loggregator-agent
+    version: 6.3.3
+    url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.3
+    sha1: e8386f41e967cc609a3e9a1d6ecf674c3c903fb3
+  
+  - name: rabbitmq-metrics-emitter
+    version: 0.4.1
+    url:     https://github.com/starkandwayne/rabbitmq-metrics-emitter-release/releases/download/v0.4.1/rabbitmq-metrics-emitter-0.4.1.tgz
+    sha1:    05afc6f3559f45e0696c6a3760242045640e0df8
+
 stemcells:
 - alias: default
   os: ubuntu-bionic
@@ -134,3 +144,66 @@ addons:
           network: (( grab params.cf.core_network ))
           query: _
 <% end %>
+      - name:    rabbitmq
+        release: rabbitmq-forge
+        properties:
+          rabbitmq:
+            default:
+              user: rabbit
+              password: (( grab meta.password ))
+            admin:
+              user: (( grab meta.username ))
+              pass: (( grab meta.password ))
+            tls:
+              enabled: (( grab meta.rabbitmq.tls.enabled || false ))
+              dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
+              ca: (( grab meta.rabbitmq.tls.ca || "" ))
+              crt: (( grab meta.rabbitmq.tls.crt || "" ))
+              key: (( grab meta.rabbitmq.tls.key || "" ))
+
+        provides:
+          rabbitmq-servers:
+            as: rabbitmq-servers
+            ip_addresses: false
+        consumes:
+          rabbitmq-servers:
+            from: rabbitmq-servers
+            ip_addresses: false
+
+      - name: loggregator_agent
+        release: loggregator-agent
+        consumes:
+          doppler:
+            from: doppler
+            deployment: (( grab meta.cf.deployment_name ))
+        properties:
+          loggregator:
+            tls:
+              ca_cert: (( vault meta.cf.exodus_path ":loggregator_ca" ))
+              agent:
+                cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
+                key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
+          metrics:
+            server_name: (( concat genesis.env "-rabbitmq-metrics-emitter" ))
+            ca_cert: (( vault meta.vault "/loggregator-agent/certs/ca:certificate" ))
+            cert:    (( vault meta.vault "/loggregator-agent/certs/metrics:certificate" ))
+            key:     (( vault meta.vault "/loggregator-agent/certs/metrics:key" ))
+
+      - name: rabbitmq-metrics-emitter
+        release: rabbitmq-metrics-emitter
+        properties:
+          rabbitmq_metrics_emitter:
+            cloud_foundry:
+              api:    (( grab meta.cf.api_url ))
+              skip_ssl_validation: (( grab params.cf_skip_ssl_validation ))
+              username:   (( vault meta.cf.exodus_path ":admin_username" ))
+              password:   (( vault meta.cf.exodus_path ":admin_password" ))
+            rmq_management:
+              endpoint: (( concat meta.mgmt_scheme "://" params.mgmt_domain ":" meta.mgmt_port "/api" ))
+              user: management
+              password: (( vault meta.vault "/rabbitmq/admin/management:password" ))
+            loggregator:
+              tls:
+                cert: (( vault meta.cf.exodus_path ":loggregator_tls_agent_cert" ))
+                key: (( vault meta.cf.exodus_path ":loggregator_tls_agent_key" ))
+                ca_cert: (( vault meta.cf.exodus_path ":loggregator_ca" ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -190,6 +190,7 @@ addons:
         release: rabbitmq-forge
         properties:
           rabbitmq:
+            vhost: (( grab meta.params.instance_id || "/" ))
             default:
               user: rabbit
               password: (( grab meta.password ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -190,7 +190,7 @@ addons:
         release: rabbitmq-forge
         properties:
           rabbitmq:
-            vhost: (( grab meta.params.instance_id || "/" ))
+            vhost: f680fee2-cd83-4f4b-a24f-a91ceb05fbe9
             default:
               user: rabbit
               password: (( grab meta.password ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -26,6 +26,7 @@ params:
   
   mgmt_port:   15671
   mgmt_scheme: https
+  rabbitmq_host: <%= spec.networks.default.ip %>
 
 variables:
 - name: rabbitmq_metrics_emitter_ca
@@ -37,7 +38,7 @@ variables:
   type: certificate
   options:
     ca: rabbitmq_metrics_emitter_ca
-    common_name: ((internal_ip))
+    common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
 
 features:
   use_dns_addresses: true
@@ -49,6 +50,11 @@ releases:
   - { name: bpm, version: latest }
   - { name: bosh-dns-aliases, version: latest}
 <% end -%>
+
+  - name: bpm
+    version: 1.1.12
+    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.12
+    sha1: 502e9446fa34accaf122ad2b28b6ffa543d5bbca
 
   - name: loggregator-agent
     version: 6.3.3
@@ -195,6 +201,9 @@ addons:
             from: rabbitmq-servers
             ip_addresses: false
 
+      - name:    bpm
+        release: bpm
+
       - name: loggregator_agent
         release: loggregator-agent
         consumes:
@@ -210,9 +219,9 @@ addons:
                 key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
           metrics:
             server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-            ca_cert: (( rabbitmq_metrics_emitter_ca ))
-            cert:    (( rabbitmq_metrics_emitter_crt.certificate ))
-            key:     (( rabbitmq_metrics_emitter_crt.key ))
+            ca_cert: ((rabbitmq_metrics_emitter_ca))
+            cert:    ((rabbitmq_metrics_emitter_crt.certificate))
+            key:     ((rabbitmq_metrics_emitter_crt.private_key))
 
       - name: rabbitmq-metrics-emitter
         release: rabbitmq-metrics-emitter
@@ -224,7 +233,7 @@ addons:
               username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
               password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
             rmq_management:
-              endpoint: (( concat meta.mgmt_scheme "://" jobs.standalone/0.ips[0] ":" meta.mgmt_port "/api" ))
+              endpoint: (( concat meta.mgmt_scheme "://" meta.rabbitmq_host ":" meta.mgmt_port "/api" ))
               user: (( grab meta.username ))
               password: (( grab meta.password ))
             loggregator:

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/blacksmith_rabbitmq_services.ca
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/blacksmith_rabbitmq_services.ca
@@ -1,1 +1,0 @@
-<%= p('blacksmith_rabbitmq_services.tls.ca_cert') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/blacksmith_rabbitmq_services.ca
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/blacksmith_rabbitmq_services.ca
@@ -1,0 +1,1 @@
+<%= p('blacksmith_rabbitmq_services.tls.ca_cert') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.ca
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.ca
@@ -1,0 +1,1 @@
+<%= p('loggregator.tls.ca_cert') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.crt
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.crt
@@ -1,0 +1,1 @@
+<%= p('loggregator.tls.agent.cert') %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.key
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.key
@@ -1,0 +1,1 @@
+<%= p('loggregator.tls.agent.key') %>

--- a/jobs/rabbitmq/spec
+++ b/jobs/rabbitmq/spec
@@ -60,6 +60,9 @@ properties:
   rabbitmq.default.pass:
     description: "Rabbitmq default password"
     default: rabbit
+  rabbitmq.vhost:
+    description: "RabbitMQ VHost"
+    default: /
 
   rabbitmq.vhost:
     description: "RabbitMQ VHost"

--- a/jobs/rabbitmq/templates/bin/post-start
+++ b/jobs/rabbitmq/templates/bin/post-start
@@ -22,7 +22,6 @@ authenticate_user() {
 
 set_admin_vhost_permissions() {
   [[ $RABBITMQ_VHOST == "/" ]] || rabbitmqctl add_vhost "${RABBITMQ_VHOST}"
-
   rabbitmqctl set_permissions -p "${RABBITMQ_VHOST:-/}" "$RABBITMQ_ADMIN_USER" \
     "${RABBITMQ_VHOST_CONF-.*}" "${RABBITMQ_VHOST_WRITE-.*}" "${RABBITMQ_VHOST_READ-.*}"
 }


### PR DESCRIPTION
The proposed changes allow for standalone rmq service to be deployed with:  
* [rabbitmq-metrics-emitter-release](https://github.com/starkandwayne/rabbitmq-metrics-emitter-release) along with its dependencies 
* [bpm-release](https://github.com/cloudfoundry/bpm-release) and 
* [loggregator-agent-release](https://github.com/cloudfoundry/loggregator-agent-release).

Summary
* It depends on `blacksmith_services_ca` CA certificate which is created with [blacksmith-boshrelease](https://github.com/blacksmith-community/blacksmith-boshrelease/pull/18). 
* It creates a number of `meta` values and certificate `variables` that are fed conveniently  as jobs properties. 
* It creates a number of certificate template files which are populated through properties