### PR TITLE
removed dual vhost reference on spec

### DIFF
--- a/jobs/rabbitmq/spec
+++ b/jobs/rabbitmq/spec
@@ -64,10 +64,6 @@ properties:
     description: "RabbitMQ VHost"
     default: /
 
-  rabbitmq.vhost:
-    description: "RabbitMQ VHost"
-    default: /
-
   rabbitmq.verify_peer:
     description: "Validate peer and fail if no peer cert."
     default: false


### PR DESCRIPTION
`rabbitmq.vhost` already appears on lines [63-65](https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/blob/master/jobs/rabbitmq/spec#L63-L65)