### PR TITLE
decoupling bosh_env from env on ca

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -15,6 +15,7 @@ params:
 <% end -%>
 
   environment: <%= p('environment') %>
+  bosh_env: <%= p('bosh_env') %>
 
   cf:
     exodus_path: <%= p('cf.exodus_path') %>
@@ -33,7 +34,7 @@ variables:
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
-    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
+    ca: (( concat "/" meta.bosh_env "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-metrics-emitter.bosh" ))
   consumes:
     common_name:
@@ -44,7 +45,7 @@ variables:
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
-    ca: (( concat "/" meta.environment "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
+    ca: (( concat "/" meta.bosh_env "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
   consumes:
     alternative_name: 


### PR DESCRIPTION
Credhub path relied on environment name to deduct the bosh environment name used to create and store the certificate. The proposed changes uses `bosh_env` which defaults to [environment](https://github.com/genesis-community/blacksmith-genesis-kit/pull/51/commits/c80d97aaf03ab7a4de730f1c5817b9bd118e0237) if that is not present, also allowing to use a different naming convention for the director used.