### PR TITLE
Fixes failure to merge service deployment manifest

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Bugs
+
+* Fixes failure to merge service deployment manifest with credentials.yml for cluster plan @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -11,8 +11,8 @@ credentials:
   password:      (( grab meta.password ))
   uris:          (( cartesian-product "amqp://" meta.username ":" meta.password "@" jobs.node.ips ":" credentials.rmq_port ))
   uri:           (( grab credentials.uris[0] ))
-  hostnames:     (( grab jobs.standalone/0.ips ))
-  hostname:      (( grab jobs.standalone/0.ips[0] ))
+  hostnames:     (( grab jobs.node.ips ))
+  hostname:      (( grab credentials.hosts[0] ))
   protocols:
     amqp:
       username:  (( grab meta.username ))


### PR DESCRIPTION
Deploying a cluster plan produces the following error on blacksmith:

```
ERROR [9b6836f4-6f4d-479f-b534-483622ee9f17] failed to merge service deployment manifest with credentials.yml: 3 error(s) detected:
- $.credentials.dashboard_url: Unable to resolve `credentials.hostnames.0`: $.credentials.hostnames [=(( grab jobs.standalone/0.ips ))] is a scalar (not a map or a list)
- $.credentials.hostname: Unable to resolve `jobs.standalone/0.ips.0`: `$.jobs.standalone/0` could not be found in the datastructure
- $.credentials.hostnames: Unable to resolve `jobs.standalone/0.ips`: `$.jobs.standalone/0` could not be found in the datastructure
```

This is due to pointing `hostnames` and `hostname` to `standalone` which is not present on the cluster plan. The proposed fix replaces the reference with one available under a cluster plan.