### PR TITLE
fix identation

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -10,8 +10,8 @@ meta:
 
 <% if p("rabbitmq.route_registrar.enabled") -%>
 params:
-   cf:
-     core_network: <%= p("cf.core_network") %>
+  cf:
+    core_network: <%= p("cf.core_network") %>
 <% end -%>
 
   environment: <%= p('environment') %>


### PR DESCRIPTION
addresses:

```
Failed to read SERVICE directories: /var/vcap/data/blacksmith/rabbitmq-forge/services: /var/vcap/data/blacksmith/rabbitmq-forge/services/service.yml: yaml: line 12: did not find expected key
```

