### PR TITLE
route registrar and spec cleanup

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Bugs
+
+* Refactor standalone manifest to allow the clash of addons when enabling rabbitmq-dashboard-registration  - @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -58,6 +58,7 @@ properties:
   
   cf.system_domain:
     description: The top level cloudfoundry domain
+    default: ""
 
   cf.api_url:
     description: url of the cf api
@@ -130,14 +131,9 @@ properties:
     description: Network for RabbitMQ Service Deployment
     default: rabbitmq-service
 
-  # When using either dashboard or autoscaler queue depth
-  cf.deployment_name:
-    description: BOSH CF deployment name
+  # When using dashboard
   cf.core_network:
     description: CF Core network
-  cf.system_domain:
-    description:  CF system domain to use for route registration
-    default: ""
 
   bosh.deployment_name:
     description: BOSH environment deployment name

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -133,6 +133,55 @@ instance_groups:
     - name: rabbitmq-alias-domain
       type: placeholder
 
+  - name:    bpm
+    release: bpm
+
+  - name: loggregator_agent
+    release: loggregator-agent
+    consumes:
+      doppler:
+        from: doppler
+        deployment: (( grab meta.cf.deployment_name ))
+    properties:
+      loggregator:
+        tls:
+          ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+          agent:
+            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+      metrics:
+        server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
+        ca_cert: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
+        cert:    ((rabbitmq_metrics_emitter_crt.certificate))
+        key:     ((rabbitmq_metrics_emitter_crt.private_key))
+
+  - name: rabbitmq-metrics-emitter
+    release: rabbitmq-metrics-emitter
+    properties:
+      rabbitmq_metrics_emitter:
+        cloud_foundry:
+          api:    (( grab meta.cf.api_url ))
+          skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation') %>
+          username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
+          password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
+        rmq_management:
+          skip_ssl_validation: (( grab meta.mgmt_ssl ))
+          endpoint: (( concat meta.mgmt_scheme "://" meta.mgmt_host ":" meta.mgmt_port "/api" ))
+          user: (( grab meta.username ))
+          password: (( grab meta.password ))
+        loggregator:
+          tls:
+            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+            ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+
+    provides:
+      rabbitmq-emitter:
+        as: rabbitmq-emitter
+        ip_addresses: false
+    custom_provider_definitions:
+    - name: rabbitmq-emitter
+      type: address
 
 <% if p("rabbitmq.route_registrar.enabled") -%>
   - name: route_registrar
@@ -192,52 +241,3 @@ addons:
           query: _
 <% end %>
 
-  - name:    bpm
-    release: bpm
-
-  - name: loggregator_agent
-    release: loggregator-agent
-    consumes:
-      doppler:
-        from: doppler
-        deployment: (( grab meta.cf.deployment_name ))
-    properties:
-      loggregator:
-        tls:
-          ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
-          agent:
-            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
-            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
-      metrics:
-        server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-        ca_cert: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
-        cert:    ((rabbitmq_metrics_emitter_crt.certificate))
-        key:     ((rabbitmq_metrics_emitter_crt.private_key))
-
-  - name: rabbitmq-metrics-emitter
-    release: rabbitmq-metrics-emitter
-    properties:
-      rabbitmq_metrics_emitter:
-        cloud_foundry:
-          api:    (( grab meta.cf.api_url ))
-          skip_ssl_validation: <%= p('rabbitmq_metrics_emitter.cloud_foundry.skip_ssl_validation') %>
-          username: <%= p('rabbitmq_metrics_emitter.cloud_foundry.username') %>
-          password: <%= p('rabbitmq_metrics_emitter.cloud_foundry.password') %>
-        rmq_management:
-          skip_ssl_validation: (( grab meta.mgmt_ssl ))
-          endpoint: (( concat meta.mgmt_scheme "://" meta.mgmt_host ":" meta.mgmt_port "/api" ))
-          user: (( grab meta.username ))
-          password: (( grab meta.password ))
-        loggregator:
-          tls:
-            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
-            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
-            ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
-
-    provides:
-      rabbitmq-emitter:
-        as: rabbitmq-emitter
-        ip_addresses: false
-    custom_provider_definitions:
-    - name: rabbitmq-emitter
-      type: address


### PR DESCRIPTION
Allow for jobs (previously bellow route_registrar.enabled) to remain unaffected (not considered addons) when `route_registrar.enabled` is set to true.