### PR TITLE
cluster crt variables and properties

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -6,6 +6,19 @@ meta:
     azs: [z1,z2]
   username: (( vault $CREDENTIALS "/rabbitmq/system:username" ))
   password: (( vault $CREDENTIALS "/rabbitmq/system:password" ))
+  environment: <%= p('environment') %>
+  bosh_env: <%= p('bosh_env') %>
+
+variables:
+- name: rabbitmq_cluster_crt
+  type: certificate
+  options:
+    ca: (( concat "/" meta.bosh_env "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
+    common_name: (( concat meta.environment "-rabbitmq-cluster.bosh" ))
+  consumes:
+    alternative_name: 
+      from: rabbitmq-san 
+      properties: { wildcard: true }
 
 features:
   use_dns_addresses: true
@@ -39,8 +52,34 @@ instance_groups:
         properties:
           default_user:     (( grab meta.username ))
           default_password: (( grab meta.password ))
-          rabbitmq:         (( grab meta.rabbitmq ))
+          rabbitmq:
+            vhost: (( grab meta.params.instance_id || "/" ))
+            network: (( grab meta.net || "rabbitmq-service" ))
+            
+            tls:
+              enabled: (( grab meta.rabbitmq.tls.enabled || false ))
+              dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
+              ca: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
+              crt: ((rabbitmq_cluster_crt.certificate))
+              key: ((rabbitmq_cluster_crt.private_key))
+
         provides:
-          rabbitmq-servers: { as: rabbitmq-servers,   ip_addresses: false }
+          rabbitmq-servers:
+            as: rabbitmq-servers
+            ip_addresses: false
+          rabbitmq-san:
+            as: rabbitmq-san
+            ip_addresses: false
+          rabbitmq-alias-domain:
+            aliases:
+            - domain: "_.rabbitmq_standalone.bosh"
+              placeholder_type: uuid
         consumes:
-          rabbitmq-servers: { from: rabbitmq-servers, ip_addresses: false }
+          rabbitmq-servers:
+            from: rabbitmq-servers
+            ip_addresses: false
+        custom_provider_definitions:
+        - name: rabbitmq-san  
+          type: address
+        - name: rabbitmq-alias-domain
+          type: placeholder


### PR DESCRIPTION
* Moves the crt references from meta.rabbitmq to the job's specification
* Adds meta for the `environment` and `bosh_env`
* Adds variables for the certificate creation