### PR TITLE
dashboard url based on DNS

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Features
+
+* Adds access to rabbitmq cluster dashboard though a routable dns entry. @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -1,6 +1,10 @@
 ---
 credentials:
+<% if p("cf.system_domain") != "" -%>
+  dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
+<% else -%>
   dashboard_url: ((  concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
+<% end -%>
   rmq_port:      5672
   tls_port:      5671
   mgmt_port:     15672


### PR DESCRIPTION
Adds access to rabbitmq cluster dashboard though a routable dns entry