### PR TITLE
route registrar and dependencies for cluster plan

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Features
+
+* Route registration on dns based dashboard url for cluster plans. @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -1,7 +1,7 @@
 ---
 credentials:
 <% if p("cf.system_domain") != "" -%>
-  dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
+  dashboard_url: (( concat "https://" id "." name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
 <% else -%>
   dashboard_url: ((  concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
 <% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -9,6 +9,12 @@ meta:
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
 
+<% if p("rabbitmq.route_registrar.enabled") -%>
+params:
+  cf:
+    core_network: <%= p("cf.core_network") %>
+<% end -%>
+
 variables:
 - name: rabbitmq_cluster_crt
   type: certificate
@@ -25,6 +31,15 @@ features:
 
 releases:
   - { name: rabbitmq-forge, version: latest }
+<% if p("rabbitmq.route_registrar.enabled") %>
+  - { name: routing, version: latest }
+  - { name: bosh-dns-aliases, version: latest}
+<% end -%>
+
+  - name: bpm
+    version: 1.1.12
+    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.12
+    sha1: 502e9446fa34accaf122ad2b28b6ffa543d5bbca
 
 stemcells:
 - alias: default
@@ -72,7 +87,7 @@ instance_groups:
             ip_addresses: false
           rabbitmq-alias-domain:
             aliases:
-            - domain: "_.rabbitmq_standalone.bosh"
+            - domain: "_.rabbitmq_cluster.bosh"
               placeholder_type: uuid
         consumes:
           rabbitmq-servers:
@@ -83,3 +98,65 @@ instance_groups:
           type: address
         - name: rabbitmq-alias-domain
           type: placeholder
+
+      - name:    bpm
+        release: bpm
+
+<% if p("rabbitmq.route_registrar.enabled") -%>
+      - name: route_registrar
+        release: routing
+        properties:
+          nats:
+            tls:
+              enabled: true
+              client_cert: "((/<%= p("bosh.deployment_name") %>-bosh/<%= p("cf.deployment_name") %>/nats_client_cert.certificate))"
+              client_key: "((/<%= p("bosh.deployment_name") %>-bosh/<%= p("cf.deployment_name") %>/nats_client_cert.private_key))"
+          route_registrar:
+            logging_level: "debug"
+            routes:
+            - name: (( grab name ))
+              uris:
+              - (( concat id "." name ".<%= p("cf.system_domain") %>" ))
+              registration_interval: 10s
+<% if p("rabbitmq.route_registrar.tls.enabled") == "true" %>
+              tls_port: 15671
+              server_cert_domain_san: (( concat id "." name ".<%= p("cf.system_domain") %>" ))
+<% else %>
+              port: 15672
+<% end %>
+
+        consumes:
+          nats:
+            from: nats
+            deployment: <%= p("cf.deployment_name") %>
+          nats-tls:
+            from: nats-tls
+            deployment: <%= p("cf.deployment_name") %>
+
+addons:
+- name: bosh-dns-aliases
+  include:
+    jobs:
+    - name: route_registrar
+      release: routing
+  jobs:
+  - name: bosh-dns-aliases
+    release: bosh-dns-aliases
+    properties:
+      aliases:
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: (( grab meta.cf.deployment_name ))
+          domain: bosh
+          instance_group: nats
+          network: (( grab params.cf.core_network ))
+          query: '*'
+      - domain: _.nats.service.cf.internal
+        targets:
+        - deployment: (( grab meta.cf.deployment_name ))
+          domain: bosh
+          instance_group: nats
+          network: (( grab params.cf.core_network ))
+          query: _
+<% end %>
+


### PR DESCRIPTION
* Unique dashboard url including `id`
* `core_network` param
* routing, bosh-dns-aliases and bpm releases
