### PR TITLE
decouple tls from dual mode - defaults to no

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/bin/configure-blacksmith
+++ b/jobs/rabbitmq-blacksmith-plans/templates/bin/configure-blacksmith
@@ -53,10 +53,12 @@ meta:
   rabbitmq:
     tls:
       enabled: true
-      dual-mode: true
       ca: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/rabbitmq.ca" ))
       key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/rabbitmq.key" ))
       crt: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/rabbitmq.crt" ))
+<% end %>
+<% if p('rabbitmq.tls.dual-mode') -%> 
+      dual-mode: true
 <% end %>
 EOF
 <% end -%>

--- a/jobs/rabbitmq/spec
+++ b/jobs/rabbitmq/spec
@@ -34,7 +34,7 @@ properties:
     default: false
   rabbitmq.tls.dual-mode:
     description: "Allow for TLS (5671) and Non-TLS (5672) both."
-    default: true
+    default: false
   rabbitmq.tls.port:
     description: "TLS Port"
     default: 5671


### PR DESCRIPTION
* Sets default of `dual-mode` to `false
* enables `dual-mode` based on the property itself, not based on tls