### PR TITLE
disables listener and amqp when required

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Features
+
+* Disables tcp listener (5672) when tls is enabled. @itsouvalas
+* amqp connection details on `credentials.yml` only appear when required. @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -18,6 +18,7 @@ credentials:
   hostnames:     (( grab jobs.standalone/0.ips ))
   hostname:      (( grab jobs.standalone/0.ips[0] ))
   protocols:
+<% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
     amqp:
       username:  (( grab meta.username ))
       password:  (( grab meta.password ))
@@ -27,6 +28,7 @@ credentials:
       uris:      (( grab credentials.uris ))
       uri:       (( grab credentials.protocols.amqp.uris[0] ))
       ssl: false
+<% end -%>
     amqps:
       username:  (( grab meta.username ))
       password:  (( grab meta.password ))

--- a/jobs/rabbitmq/templates/config/rabbitmq.conf.erb
+++ b/jobs/rabbitmq/templates/config/rabbitmq.conf.erb
@@ -2,6 +2,10 @@
 listeners.tcp.default = <%= p('rabbitmq.port') %> # 5672
 <% end -%>
 
+<% if (p("rabbitmq.tls.enabled") && ! p("rabbitmq.tls.dual-mode")) -%>
+listeners.tcp = none %> # disables non-tls
+<% end -%>
+
 <% if p("rabbitmq.tls.enabled") -%>
 # https://www.rabbitmq.com/ssl.html
 


### PR DESCRIPTION
* Disables tcp listener (5672) when tls is enabled.
* amqp connection details on `credentials.yml` only appear when required.