### PR TITLE
add Management user/fix cluster admin/cleanup

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,11 @@
+# Features
+
+* Adds a user with the [management](https://www.rabbitmq.com/management.html#permissions) tag/role @itsouvalas
+
+# Bugs
+
+* Fix admin user credentials on cluster plans not passed on properly @itsouvalas
+
+# Chores
+
+* Cleanup reference to unused `default` user for fabbitmq standalone plan @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -5,6 +5,8 @@ credentials:
 <% else -%>
   dashboard_url: ((  concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
 <% end -%>
+  management_username: (( grab meta.username-management ))
+  management_password: (( grab meta.password-management ))
   rmq_port:      5672
   tls_port:      5671
   mgmt_port:     15672
@@ -18,6 +20,7 @@ credentials:
   hostnames:     (( grab jobs.node.ips ))
   hostname:      (( grab credentials.hosts[0] ))
   protocols:
+  <% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
     amqp:
       username:  (( grab meta.username ))
       password:  (( grab meta.password ))
@@ -28,6 +31,7 @@ credentials:
       ssl: false
       uris:      (( grab credentials.uris ))
       uri:       (( grab credentials.protocols.amqp.uris[0] ))
+<% end -%>
     amqps:
       username:  (( grab meta.username ))
       password:  (( grab meta.password ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/init
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/init
@@ -4,4 +4,7 @@ set -eu
 safe gen $CREDENTIALS/rabbitmq/system username
 safe gen $CREDENTIALS/rabbitmq/system password
 
+safe gen $CREDENTIALS/rabbitmq/management username
+safe gen $CREDENTIALS/rabbitmq/management password
+
 exit 0

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -6,6 +6,8 @@ meta:
     azs: [z1,z2]
   username: (( vault $CREDENTIALS "/rabbitmq/system:username" ))
   password: (( vault $CREDENTIALS "/rabbitmq/system:password" ))
+  username-management: (( vault $CREDENTIALS "/rabbitmq/management:username" ))
+  password-management: (( vault $CREDENTIALS "/rabbitmq/management:password" ))
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
 
@@ -73,12 +75,15 @@ instance_groups:
       - name:    rabbitmq
         release: rabbitmq-forge
         properties:
-          default_user:     (( grab meta.username ))
-          default_password: (( grab meta.password ))
           rabbitmq:
             vhost: (( grab meta.params.instance_id || "/" ))
             network: (( grab meta.net || "rabbitmq-service" ))
-            
+            admin:
+              user: (( grab meta.username ))
+              pass: (( grab meta.password ))
+            management:
+              user: (( grab meta.username-management ))
+              pass: (( grab meta.password-management ))
             tls:
               enabled: (( grab meta.rabbitmq.tls.enabled || false ))
               dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -5,6 +5,8 @@ credentials:
 <% else -%>
   dashboard_url: (( concat "https://" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/#/login/"  meta.username "/" meta.password ))
 <% end -%>
+  management_username: (( grab meta.username-management ))
+  management_password: (( grab meta.password-management ))
   rmq_port:      5672
   tls_port:      5671
   mgmt_port:     15672

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/init
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/init
@@ -4,4 +4,7 @@ set -eu
 safe gen $CREDENTIALS/rabbitmq/system username
 safe gen $CREDENTIALS/rabbitmq/system password
 
+safe gen $CREDENTIALS/rabbitmq/management username
+safe gen $CREDENTIALS/rabbitmq/management password
+
 exit 0

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -3,6 +3,8 @@ meta:
   size: default
   username: (( vault $CREDENTIALS "/rabbitmq/system:username" ))
   password: (( vault $CREDENTIALS "/rabbitmq/system:password" ))
+  username-management: (( vault $CREDENTIALS "/rabbitmq/management:username" ))
+  password-management: (( vault $CREDENTIALS "/rabbitmq/management:password" ))
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
 
@@ -99,12 +101,12 @@ instance_groups:
       rabbitmq:
         vhost: (( grab meta.params.instance_id || "/" ))
         network: (( grab meta.net || "rabbitmq-service" ))
-        default:
-          user: rabbit
-          password: (( grab meta.password ))
         admin:
           user: (( grab meta.username ))
           pass: (( grab meta.password ))
+        management:
+          user: (( grab meta.username-management ))
+          pass: (( grab meta.password-management ))
         tls:
           enabled: (( grab meta.rabbitmq.tls.enabled || false ))
           dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))

--- a/jobs/rabbitmq/spec
+++ b/jobs/rabbitmq/spec
@@ -54,6 +54,12 @@ properties:
   rabbitmq.admin.pass:
     description: "Rabbitmq admin password"
     default: admin
+  rabbitmq.management.user:
+    description: "Rabbitmq user with management tag/role"
+    default: management
+  rabbitmq.management.pass:
+    description: "Rabbitmq pass for user with management tag/role"
+    default: management
   rabbitmq.default.user:
     description: "Rabbitmq default username"
     default: rabbit

--- a/jobs/rabbitmq/templates/bin/post-start
+++ b/jobs/rabbitmq/templates/bin/post-start
@@ -26,6 +26,27 @@ set_admin_vhost_permissions() {
     "${RABBITMQ_VHOST_CONF-.*}" "${RABBITMQ_VHOST_WRITE-.*}" "${RABBITMQ_VHOST_READ-.*}"
 }
 
+create_management_user() {
+  rabbitmqctl add_user "$RABBITMQ_MANAGEMENT_USER" "$RABBITMQ_MANAGEMENT_PASS"
+}
+
+set_management_user_role() {
+  rabbitmqctl set_user_tags "$RABBITMQ_MANAGEMENT_USER" "management"
+}
+
+reset_management_user_pass() {
+  rabbitmqctl change_password "$RABBITMQ_MANAGEMENT_USER" "$RABBITMQ_MANAGEMENT_PASS"
+}
+
+authenticate_management_user() {
+  rabbitmqctl authenticate_user "${RABBITMQ_MANAGEMENT_USER}" "${RABBITMQ_MANAGEMENT_PASS}"
+}
+
+set_management_vhost_permissions() {
+  rabbitmqctl set_permissions -p "${RABBITMQ_VHOST:-/}" "$RABBITMQ_MANAGEMENT_USER" \
+    "${RABBITMQ_VHOST_CONF-.*}" "${RABBITMQ_VHOST_READ-.*}"
+}
+
 wait_for_rabbitmq_startup() {
   rabbitmqctl eval -t ${RABBITMQ_EVAL_TIMEOUT} 'rabbit:await_startup().'
 }
@@ -38,5 +59,12 @@ authenticate_user || (
 )
 set_admin_user_role
 set_admin_vhost_permissions
+
+authenticate_management_user || (
+  create_management_user || reset_management_user_pass
+  authenticate_management_user
+)
+set_management_user_role
+set_management_vhost_permissions
 
 exit 0

--- a/jobs/rabbitmq/templates/env.rb
+++ b/jobs/rabbitmq/templates/env.rb
@@ -11,6 +11,8 @@ export STORE_DIR=/var/vcap/store/rabbitmq
 # RabbitMQ
 export RABBITMQ_ADMIN_PASS="<%= p('rabbitmq.admin.pass') %>"
 export RABBITMQ_ADMIN_USER="<%= p('rabbitmq.admin.user') %>"
+export RABBITMQ_MANAGEMENT_PASS="<%= p('rabbitmq.management.pass') %>"
+export RABBITMQ_MANAGEMENT_USER="<%= p('rabbitmq.management.user') %>"
 export RABBITMQ_CONFIG_FILE=${JOB_DIR}/config/rabbitmq.conf
 export RABBITMQ_LOG_BASE=${LOG_DIR}
 export RABBITMQ_MNESIA_BASE=/var/vcap/store/rabbitmq


### PR DESCRIPTION
* updates `init` script to create an additional `management` user on vault
* updates `manifest.yml` to:
  * pull those credentials from vault
  * provide them as a property to the `rabbitmq` job under `management.user` and `management.pass` respectively
* updates `env.rb` to export env vars for the management user using `rabbitmq` job properties.
* updates `post-start` script to create the user on rabbitmq using the information provided on `env.rb`
* updates `credentilas.yml` to display the management user credentials