### PR TITLE
api_url plan type and guest user

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Features
+
+* Add `api_url` on credentials to be used in future implementation of binding using dynamic credentials. @itsouvalas
+* Exports plan type as environment variable in the deployed service instance. @itsouvalas
+* Guest user deletion is based on plan being `standalone`. @itsouvalas

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -2,8 +2,10 @@
 credentials:
 <% if p("cf.system_domain") != "" -%>
   dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
+  api_url:       (( concat "https://" name ".<%= p("cf.system_domain") %>/api" ))
 <% else -%>
-  dashboard_url: ((  concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
+  dashboard_url: (( concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
+  api_url:       (( concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/api" ))
 <% end -%>
   monitoring_username: (( grab meta.username-monitoring ))
   monitoring_password: (( grab meta.password-monitoring ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -2,8 +2,10 @@
 credentials:
 <% if p("cf.system_domain") != "" -%>
   dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
+  api_url:       (( concat "https://" name ".<%= p("cf.system_domain") %>/api" ))
 <% else -%>
   dashboard_url: (( concat "https://" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/#/login/"  meta.username "/" meta.password ))
+  api_url:       (( concat "https://" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/api" ))
 <% end -%>
   monitoring_username: (( grab meta.username-monitoring ))
   monitoring_password: (( grab meta.password-monitoring ))

--- a/jobs/rabbitmq/templates/bin/post-start
+++ b/jobs/rabbitmq/templates/bin/post-start
@@ -105,6 +105,8 @@ authenticate_user
 set_app_user_role
 set_app_vhost_permissions
 
-remove_guest_user
+if [ $RABBITMQ_PLAN == "standalone" ]; then
+  remove_guest_user
+fi
 
 exit 0

--- a/jobs/rabbitmq/templates/env.rb
+++ b/jobs/rabbitmq/templates/env.rb
@@ -9,6 +9,7 @@ export TMP_DIR=/var/vcap/sys/tmp/rabbitmq
 export STORE_DIR=/var/vcap/store/rabbitmq
 
 # RabbitMQ
+export RABBITMQ_PLAN="<%= p('rabbitmq.plan') %>"
 export RABBITMQ_ADMIN_PASS="<%= p('rabbitmq.admin.pass') %>"
 export RABBITMQ_ADMIN_USER="<%= p('rabbitmq.admin.user') %>"
 export RABBITMQ_MONITORING_PASS="<%= p('rabbitmq.monitoring.pass') %>"


### PR DESCRIPTION
* Add `api_url` on credentials to be used in future implementation of binding using dynamic credentials
* Exports plan type as environment variable in the deployed service instance
* Guest user deletion is based on plan being `standalone`