### PR TITLE
As tl feature

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,10 @@
+# Features
+
+* Expects `rabbitmq-autoscale` as a distinct feature from blacksmith-genesis-kit deployment to enable autoscaling based on queue depth. @itsouvalas
+* When `rabbitmq-tls` is used unless `rabbitmq-dual-mode` is also used it ensures communication is allowed only through tls. @itsouvalas
+
+# Chores
+
+* Credentials on blacksmith UI and those provided during bind and service-key include endpoints related to the features selected. @itsouvalas
+* Job's templates are updated to be populated only when the corresponding features are selected. @itsouvalas
+

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -119,6 +119,9 @@ properties:
     description: The Server Certificate
   rabbitmq.tls.key:
     description: The Server Key
+  rabbitmq.autoscale.enabled:
+    description: Enable autoscaling based on rabbitmq queue depth
+    default: false
 
   rabbitmq.route_registrar.enabled:
     description: Enable registration of dashbaord url with cf

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -4,8 +4,13 @@ credentials:
   dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
   api_url:       (( concat "https://" name ".<%= p("cf.system_domain") %>/api" ))
 <% else -%>
+<% if p("rabbitmq.tls.enabled") -%>
+  dashboard_url: (( concat "https://" credentials.hostnames[0] ":" credentials.tls_mgmt_port "/#/login/"  meta.username "/" meta.password ))
+  api_url:       (( concat "https://" credentials.hostnames[0] ":" credentials.tls_mgmt_port "/api" ))
+<% else -%>
   dashboard_url: (( concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
   api_url:       (( concat "http://" credentials.hostnames[0] ":" credentials.mgmt_port "/api" ))
+<% end -%>
 <% end -%>
   monitoring_username: (( grab meta.username-monitoring ))
   monitoring_password: (( grab meta.password-monitoring ))
@@ -19,8 +24,13 @@ credentials:
   vhost:         (( grab params.instance_id || "/" ))
   username:      (( grab meta.username-app ))
   password:      (( grab meta.password-app ))
+<% if ! p("rabbitmq.tls.enabled") -%>
   uris:          (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.rmq_port ))
   uri:           (( grab credentials.uris[0] ))
+<% else -%>
+  uris:          (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.tls_port ))
+  uri:           (( grab credentials.uris[0] ))
+<% end -%>
   hostnames:     (( grab jobs.node.ips ))
   hostname:      (( grab credentials.hosts[0] ))
   protocols:
@@ -33,9 +43,10 @@ credentials:
       vhost:     (( grab params.instance_id || "/" ))
       port: 5672
       ssl: false
-      uris:      (( grab credentials.uris ))
+      uris:      (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.rmq_port ))
       uri:       (( grab credentials.protocols.amqp.uris[0] ))
 <% end -%>
+<% if p("rabbitmq.tls.enabled") -%>
     amqps:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
@@ -45,6 +56,8 @@ credentials:
       uris:      (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true
+<% end -%>
+<% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
     management:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
@@ -55,6 +68,8 @@ credentials:
       ssl: false
       uris:      (( cartesian-product "http://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management.uris[0] ))
+<% end -%>
+<% if p("rabbitmq.tls.enabled") -%>
     management_tls:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
@@ -65,3 +80,4 @@ credentials:
       ssl: true
       uris:      (( cartesian-product "https://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.tls_mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management_tls.uris[0] ))
+<% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -14,6 +14,7 @@ meta:
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
 
+<% if p("rabbitmq.autoscale.enabled") -%>
   cf:
     exodus_path: <%= p('cf.exodus_path') %>
     deployment_name: <%= p('cf.deployment_name') %>
@@ -26,14 +27,14 @@ meta:
   mgmt_port:   <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_port') %>
   mgmt_scheme: <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_scheme') %>
   mgmt_host:   <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_host') %>
-
-<% if p("rabbitmq.route_registrar.enabled") -%>
-params:
-  cf:
-    core_network: <%= p("cf.core_network") %>
 <% end -%>
 
+
+<% if p("rabbitmq.autoscale.enabled") || p("rabbitmq.autoscale.enabled") -%>
 variables:
+<% end -%>
+
+<% if p("rabbitmq.autoscale.enabled") -%>
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
@@ -45,6 +46,9 @@ variables:
     alternative_name: 
       from: rabbitmq-emitter
       properties: { wildcard: true }
+<% end -%>
+
+<% if p("rabbitmq.tls.enabled") -%>
 - name: rabbitmq_cluster_crt
   type: certificate
   options:
@@ -54,6 +58,13 @@ variables:
     alternative_name: 
       from: rabbitmq-san 
       properties: { wildcard: true }
+<% end -%>
+
+<% if p("rabbitmq.route_registrar.enabled") -%>
+params:
+  cf:
+    core_network: <%= p("cf.core_network") %>
+<% end -%>
 
 features:
   use_dns_addresses: true
@@ -62,14 +73,17 @@ releases:
   - { name: rabbitmq-forge, version: latest }
 <% if p("rabbitmq.route_registrar.enabled") %>
   - { name: routing, version: latest }
-  - { name: bosh-dns-aliases, version: latest}
 <% end -%>
 
+<% if p("rabbitmq.route_registrar.enabled") || p("rabbitmq.autoscale.enabled") %>
   - name: bpm
     version: 1.1.12
     url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.12
     sha1: 502e9446fa34accaf122ad2b28b6ffa543d5bbca
+  - { name: bosh-dns-aliases, version: latest}
+<% end -%>
 
+<% if p("rabbitmq.autoscale.enabled") -%>
   - name: loggregator-agent
     version: 6.3.3
     url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.3
@@ -79,6 +93,7 @@ releases:
     version: 0.4.1
     url:     https://github.com/starkandwayne/rabbitmq-metrics-emitter-release/releases/download/v0.4.1/rabbitmq-metrics-emitter-0.4.1.tgz
     sha1:    05afc6f3559f45e0696c6a3760242045640e0df8
+<% end -%>
 
 stemcells:
 - alias: default
@@ -124,9 +139,11 @@ instance_groups:
         tls:
           enabled: (( grab meta.rabbitmq.tls.enabled || false ))
           dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
+<% if p("rabbitmq.tls.enabled") -%>
           ca: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
           crt: ((rabbitmq_cluster_crt.certificate))
           key: ((rabbitmq_cluster_crt.private_key))
+<% end -%>
 
     provides:
       rabbitmq-servers:
@@ -149,9 +166,11 @@ instance_groups:
     - name: rabbitmq-alias-domain
       type: placeholder
 
+<% if p("rabbitmq.autoscale.enabled") -%>
+<% if !p("rabbitmq.route_registrar.enabled") -%>
   - name:    bpm
     release: bpm
-
+<% end -%>
   - name: loggregator_agent
     release: loggregator-agent
     consumes:
@@ -198,6 +217,7 @@ instance_groups:
     custom_provider_definitions:
     - name: rabbitmq-emitter
       type: address
+<% end -%>
 
 <% if p("rabbitmq.route_registrar.enabled") -%>
   - name: route_registrar
@@ -229,6 +249,9 @@ instance_groups:
       nats-tls:
         from: nats-tls
         deployment: <%= p("cf.deployment_name") %>
+
+  - name:    bpm
+    release: bpm
 
 addons:
 - name: bosh-dns-aliases

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/meta.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/meta.yml
@@ -2,6 +2,7 @@
 meta:
   environment: <%= p('environment') %>
 
+<% if p("rabbitmq.autoscale.enabled") -%>
   cf:
     exodus_path: <%= p('cf.exodus_path') %>
     deployment_name: <%= p('cf.deployment_name') %>
@@ -9,3 +10,4 @@ meta:
     api_url:    <%= p('cf.api_url') %>
     username:   <%= p('cf.username') %>
     password:   <%= p('cf.password') %>
+<% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -4,23 +4,33 @@ credentials:
   dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username "/" meta.password ))
   api_url:       (( concat "https://" name ".<%= p("cf.system_domain") %>/api" ))
 <% else -%>
+<% if p("rabbitmq.tls.enabled") -%>
   dashboard_url: (( concat "https://" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/#/login/"  meta.username "/" meta.password ))
   api_url:       (( concat "https://" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/api" ))
+<% else -%>
+  dashboard_url: (( concat "http://" jobs.standalone/0.ips[0] ":" credentials.mgmt_port "/#/login/"  meta.username "/" meta.password ))
+  api_url:       (( concat "http://" jobs.standalone/0.ips[0] ":" credentials.mgmt_port "/api" ))
+<% end -%>
 <% end -%>
   monitoring_username: (( grab meta.username-monitoring ))
   monitoring_password: (( grab meta.password-monitoring ))
   admin_username:      (( grab meta.username ))
   admin_password:      (( grab meta.password ))
   rmq_port:      5672
-  tls_port:      5671
   mgmt_port:     15672
+  tls_port:      5671
   tls_mgmt_port: 15671
   vhost:         (( grab params.instance_id || "/" ))
   host:          (( grab jobs.standalone/0.ips[0] ))
   username:      (( grab meta.username-app ))
   password:      (( grab meta.password-app ))
-  uris:          (( grab credentials.protocols.amqps.uris ))
-  uri:           (( grab credentials.protocols.amqps.uris[0] ))
+<% if ! p("rabbitmq.tls.enabled") -%>
+  uris:          (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.rmq_port ))
+  uri:           (( grab credentials.uris[0] ))
+<% else -%>
+  uris:          (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.tls_port ))
+  uri:           (( grab credentials.uris[0] ))
+<% end -%>
   hostnames:     (( grab jobs.standalone/0.ips ))
   hostname:      (( grab jobs.standalone/0.ips[0] ))
   protocols:
@@ -31,10 +41,11 @@ credentials:
       host:      (( grab jobs.standalone/0.ips[0] ))
       port: 5672
       vhost:     (( grab params.instance_id || "/" ))
-      uris:      (( grab credentials.uris ))
+      uris:      (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.rmq_port ))
       uri:       (( grab credentials.protocols.amqp.uris[0] ))
       ssl: false
 <% end -%>
+<% if p("rabbitmq.tls.enabled") -%>
     amqps:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
@@ -44,6 +55,8 @@ credentials:
       uris:      (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true
+<% end -%>
+<% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
     management:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
@@ -53,6 +66,8 @@ credentials:
       uris:      (( cartesian-product "http://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management.uris[0] ))
       ssl: false
+<% end -%>
+<% if p("rabbitmq.tls.enabled") -%>
     management_tls:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
@@ -62,3 +77,4 @@ credentials:
       uris:      (( cartesian-product "https://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management_tls.uris[0] ))
       ssl: true
+<% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -11,6 +11,7 @@ meta:
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
 
+<% if p("rabbitmq.autoscale.enabled") -%>
   cf:
     exodus_path: <%= p('cf.exodus_path') %>
     deployment_name: <%= p('cf.deployment_name') %>
@@ -23,14 +24,14 @@ meta:
   mgmt_port:   <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_port') %>
   mgmt_scheme: <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_scheme') %>
   mgmt_host:   <%= p('rabbitmq_metrics_emitter.rmq_management.mgmt_host') %>
-
-<% if p("rabbitmq.route_registrar.enabled") -%>
-params:
-  cf:
-    core_network: <%= p("cf.core_network") %>
 <% end -%>
 
+
+<% if p("rabbitmq.autoscale.enabled") || p("rabbitmq.autoscale.enabled") -%>
 variables:
+<% end -%>
+
+<% if p("rabbitmq.autoscale.enabled") -%>
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
   options:
@@ -42,6 +43,9 @@ variables:
     alternative_name: 
       from: rabbitmq-emitter
       properties: { wildcard: true }
+<% end -%>
+
+<% if p("rabbitmq.tls.enabled") -%>
 - name: rabbitmq_standalone_crt
   type: certificate
   options:
@@ -51,6 +55,13 @@ variables:
     alternative_name: 
       from: rabbitmq-san 
       properties: { wildcard: true }
+<% end -%>
+
+<% if p("rabbitmq.route_registrar.enabled") -%>
+params:
+  cf:
+    core_network: <%= p("cf.core_network") %>
+<% end -%>
 
 features:
   use_dns_addresses: true
@@ -59,14 +70,17 @@ releases:
   - { name: rabbitmq-forge, version: latest }
 <% if p("rabbitmq.route_registrar.enabled") %>
   - { name: routing, version: latest }
-  - { name: bosh-dns-aliases, version: latest}
 <% end -%>
 
+<% if p("rabbitmq.route_registrar.enabled") || p("rabbitmq.autoscale.enabled") %>
   - name: bpm
     version: 1.1.12
     url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.12
     sha1: 502e9446fa34accaf122ad2b28b6ffa543d5bbca
+  - { name: bosh-dns-aliases, version: latest}
+<% end -%>
 
+<% if p("rabbitmq.autoscale.enabled") -%>
   - name: loggregator-agent
     version: 6.3.3
     url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.3
@@ -76,6 +90,7 @@ releases:
     version: 0.4.1
     url:     https://github.com/starkandwayne/rabbitmq-metrics-emitter-release/releases/download/v0.4.1/rabbitmq-metrics-emitter-0.4.1.tgz
     sha1:    05afc6f3559f45e0696c6a3760242045640e0df8
+<% end -%>
 
 stemcells:
 - alias: default
@@ -121,9 +136,11 @@ instance_groups:
         tls:
           enabled: (( grab meta.rabbitmq.tls.enabled || false ))
           dual-mode: (( grab meta.rabbitmq.tls.dual-mode || false ))
+<% if p("rabbitmq.tls.enabled") -%>
           ca: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
           crt: ((rabbitmq_standalone_crt.certificate))
           key: ((rabbitmq_standalone_crt.private_key))
+<% end -%>
 
     provides:
       rabbitmq-servers:
@@ -146,9 +163,11 @@ instance_groups:
     - name: rabbitmq-alias-domain
       type: placeholder
 
+<% if p("rabbitmq.autoscale.enabled") -%>
+<% if !p("rabbitmq.route_registrar.enabled") -%>
   - name:    bpm
     release: bpm
-
+<% end -%>
   - name: loggregator_agent
     release: loggregator-agent
     consumes:
@@ -195,6 +214,7 @@ instance_groups:
     custom_provider_definitions:
     - name: rabbitmq-emitter
       type: address
+<% end -%>
 
 <% if p("rabbitmq.route_registrar.enabled") -%>
   - name: route_registrar
@@ -226,6 +246,9 @@ instance_groups:
       nats-tls:
         from: nats-tls
         deployment: <%= p("cf.deployment_name") %>
+
+  - name:    bpm
+    release: bpm
 
 addons:
 - name: bosh-dns-aliases

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.ca
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.ca
@@ -1,1 +1,3 @@
+<% if p("rabbitmq.autoscale.enabled") -%>
 <%= p('loggregator.tls.ca_cert') %>
+<% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.crt
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.crt
@@ -1,1 +1,3 @@
+<% if p("rabbitmq.autoscale.enabled") -%>
 <%= p('loggregator.tls.agent.cert') %>
+<% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.key
+++ b/jobs/rabbitmq-blacksmith-plans/templates/tls/loggregator.key
@@ -1,1 +1,3 @@
+<% if p("rabbitmq.autoscale.enabled") -%>
 <%= p('loggregator.tls.agent.key') %>
+<% end -%>

--- a/jobs/rabbitmq/templates/config/rabbitmq.conf.erb
+++ b/jobs/rabbitmq/templates/config/rabbitmq.conf.erb
@@ -37,8 +37,10 @@ ssl_options.honor_ecc_order      = true
 
 <% if p('management.enabled') -%>
 # https://www.rabbitmq.com/management.html
+<% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
 management.tcp.port = <%= p('management.port') %>
 management.tcp.compress = true
+<% end -%>
 <% if p("rabbitmq.tls.enabled") -%>
 # https://www.rabbitmq.com/ssl.html
 # Management TLS Listener is on port 5671


### PR DESCRIPTION
# Features

* Expects `rabbitmq-autoscale` as a distinct feature from blacksmith-genesis-kit deployment to enable autoscaling based on queue depth. 
* When `rabbitmq-tls` is used unless `rabbitmq-dual-mode` is also used it ensures communication is allowed only through tls. 

# Chores

* Credentials on blacksmith UI and those provided during bind and service-key include endpoints related to the features selected. 
* Job's templates are updated to be populated only when the corresponding features are selected. 