### PR TITLE
Bosh Links, SAN and creds

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -48,6 +48,10 @@ properties:
     description: A global limit on the number of RabbitMQ services (regardless of the plan); 0 = unlimited.
     default: 0
   
+  service.type:
+    description: Differentiates between standalone and cluster type
+    default: standalone
+  
   environment:
     description: The environment name of the cloudfoundry/bosh deployment
 
@@ -126,6 +130,8 @@ properties:
   rabbitmq.autoscale.enabled:
     description: Enable autoscaling based on rabbitmq queue depth
     default: false
+  rabbitmq.hostname:
+    description: Pulls the DNS hostname of the deployed service instance
 
   rabbitmq.route_registrar.enabled:
     description: Enable registration of dashbaord url with cf

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -2,7 +2,7 @@
 credentials:
 <% if p("cf.system_domain") != "" -%>
   dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username-app "/" meta.password-app ))
-  api_url:       (( concat "https://" name ".<%= p("cf.system_domain") %>/api" ))
+  api_url:       (( concat "https://" params.hostname ":" credentials.tls_mgmt_port "/api" ))
 <% else -%>
 <% if p("rabbitmq.tls.enabled") -%>
   dashboard_url: (( concat "https://" credentials.hostnames[0] ":" credentials.tls_mgmt_port "/#/login/"  meta.username-app "/" meta.password-app ))
@@ -17,43 +17,44 @@ credentials:
   admin_username:      (( grab meta.username ))
   admin_password:      (( grab meta.password ))
   rmq_port:      5672
-  tls_port:      5671
   mgmt_port:     15672
+  tls_port:      5671
   tls_mgmt_port: 15671
   hosts:         (( grab jobs.node.ips ))
   vhost:         (( grab params.instance_id || "/" ))
+  dnsname:       (( grab params.hostname ))
   username:      (( grab meta.username-app ))
   password:      (( grab meta.password-app ))
 <% if ! p("rabbitmq.tls.enabled") -%>
-  uris:          (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.rmq_port ))
+  uris:          (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.rmq_port ))
   uri:           (( grab credentials.uris[0] ))
 <% else -%>
-  uris:          (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.tls_port ))
+  uris:          (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.tls_port ))
   uri:           (( grab credentials.uris[0] ))
 <% end -%>
-  hostnames:     (( grab jobs.node.ips ))
-  hostname:      (( grab credentials.hosts[0] ))
+  hostnames:     (( grab credentials.dnsname ))
+  hostname:      (( grab credentials.dnsname ))
   protocols:
 <% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
     amqp:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
       hosts:     (( grab jobs.node.ips ))
-      host:      (( grab credentials.hosts[0] ))
-      vhost:     (( grab params.instance_id || "/" ))
+      host:      (( grab credentials.dnsname ))
       port: 5672
-      ssl: false
-      uris:      (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.rmq_port ))
+      vhost:     (( grab params.instance_id || "/" ))
+      uris:      (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.rmq_port ))
       uri:       (( grab credentials.protocols.amqp.uris[0] ))
+      ssl: false
 <% end -%>
 <% if p("rabbitmq.tls.enabled") -%>
     amqps:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
-      host:      (( grab jobs.node.ips[0] ))
+      host:      (( grab credentials.dnsname ))
       port: 5671
       vhost:     (( grab params.instance_id || "/" ))
-      uris:      (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.tls_port ))
+      uris:      (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true
 <% end -%>
@@ -62,22 +63,22 @@ credentials:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
       hosts:     (( grab jobs.node.ips ))
-      host:      (( grab credentials.hosts[0] ))
-      path: "/api"
+      host:      (( grab credentials.dnsname ))
       port: 15672
-      ssl: false
-      uris:      (( cartesian-product "http://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.mgmt_port "/api" ))
+      path: "/api"
+      uris:      (( cartesian-product "http://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management.uris[0] ))
+      ssl: false
 <% end -%>
 <% if p("rabbitmq.tls.enabled") -%>
     management_tls:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
       hosts:     (( grab jobs.node.ips ))
-      host:      (( grab credentials.hosts[0] ))
-      path: "/api"
+      host:      (( grab credentials.dnsname ))
       port: 15671
-      ssl: true
-      uris:      (( cartesian-product "https://" meta.username-app ":" meta.password-app "@" jobs.node.ips ":" credentials.tls_mgmt_port "/api" ))
+      path: "/api"
+      uris:      (( cartesian-product "https://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.tls_mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management_tls.uris[0] ))
+      ssl: true
 <% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -30,6 +30,7 @@ meta:
 <% if p("rabbitmq.autoscale.enabled") || p("rabbitmq.tls.enabled") -%>
 variables:
 <% end -%>
+
 <% if p("rabbitmq.autoscale.enabled") -%>
 - name: rabbitmq_metrics_emitter_crt
   type: certificate
@@ -45,7 +46,7 @@ variables:
     alternative_name: 
       from: rabbitmq-emitter
 
-      properties: 
+      properties:
         wildcard: true
 <% end -%>
 
@@ -56,12 +57,11 @@ variables:
   options:
     ca: (( concat "/" meta.bosh_env "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-cluster.bosh" ))
-
+    alternative_names: [(( concat name ".<%= p("cf.system_domain") %>" ))]
   consumes:
-    alternative_name: 
-      from: rabbitmq-san 
-
-      properties: 
+    alternative_name:
+      from: rabbitmq-san
+      properties:
         wildcard: true
 <% end -%>
 
@@ -82,7 +82,7 @@ instance_groups:
   vm_type: (( grab meta.size ))
 
   networks: 
-    - name: (( grab meta.net || 'rabbitmq-service' ))
+    - name: (( grab meta.net || "rabbitmq-service" ))
 
   .: (( inject meta.disk_config )) # Accounts for persistent_disk_type option
 
@@ -141,12 +141,13 @@ instance_groups:
         type: address
       - name: rabbitmq-alias-domain
         type: placeholder
-
 <% if p("rabbitmq.autoscale.enabled") -%>
+
 <% if !p("rabbitmq.route_registrar.enabled") -%>
   - name:    bpm
     release: bpm
 <% end -%>
+
   - name: loggregator_agent
     release: loggregator-agent
 
@@ -255,6 +256,7 @@ addons:
     properties:
       aliases:
       - domain: nats.service.cf.internal
+
         targets:
         - deployment: (( grab meta.cf.deployment_name ))
           domain: bosh
@@ -262,12 +264,14 @@ addons:
           network: (( grab params.cf.core_network ))
           query: '*'
       - domain: _.nats.service.cf.internal
+
         targets:
         - deployment: (( grab meta.cf.deployment_name ))
           domain: bosh
           instance_group: nats
           network: (( grab params.cf.core_network ))
           query: _
+
 <% end -%>
 
 releases:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/service.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/service.yml
@@ -3,6 +3,7 @@ id:  <%= p('service.id') %>
 name: <%= p('service.name') %>
 description: |-
   <%= p('service.description') %>
+type: <%= p('service.type') %>
 tags:
 <% p('service.tags', []).each do |tag| -%>
   - <%= tag %>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -2,7 +2,7 @@
 credentials:
 <% if p("cf.system_domain") != "" -%>
   dashboard_url: (( concat "https://" name ".<%= p("cf.system_domain") %>/#/login/"  meta.username-app "/" meta.password-app ))
-  api_url:       (( concat "https://" name ".<%= p("cf.system_domain") %>/api" ))
+  api_url:       (( concat "https://" params.hostname ":" credentials.tls_mgmt_port "/api" ))
 <% else -%>
 <% if p("rabbitmq.tls.enabled") -%>
   dashboard_url: (( concat "https://" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/#/login/"  meta.username-app "/" meta.password-app ))
@@ -21,27 +21,28 @@ credentials:
   tls_port:      5671
   tls_mgmt_port: 15671
   vhost:         (( grab params.instance_id || "/" ))
-  host:          (( grab jobs.standalone/0.ips[0] ))
+  host:          (( grab credentials.dnsname ))
+  dnsname:       (( grab params.hostname ))
   username:      (( grab meta.username-app ))
   password:      (( grab meta.password-app ))
 <% if ! p("rabbitmq.tls.enabled") -%>
-  uris:          (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.rmq_port ))
+  uris:          (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.rmq_port ))
   uri:           (( grab credentials.uris[0] ))
 <% else -%>
-  uris:          (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.tls_port ))
+  uris:          (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.tls_port ))
   uri:           (( grab credentials.uris[0] ))
 <% end -%>
-  hostnames:     (( grab jobs.standalone/0.ips ))
-  hostname:      (( grab jobs.standalone/0.ips[0] ))
+  hostnames:     (( grab credentials.dnsname ))
+  hostname:      (( grab credentials.dnsname ))
   protocols:
 <% if ! p("rabbitmq.tls.enabled") || (p("rabbitmq.tls.enabled") && p("rabbitmq.tls.dual-mode")) -%>
     amqp:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
-      host:      (( grab jobs.standalone/0.ips[0] ))
+      host:      (( grab credentials.dnsname ))
       port: 5672
       vhost:     (( grab params.instance_id || "/" ))
-      uris:      (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.rmq_port ))
+      uris:      (( cartesian-product "amqp://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.rmq_port ))
       uri:       (( grab credentials.protocols.amqp.uris[0] ))
       ssl: false
 <% end -%>
@@ -49,10 +50,10 @@ credentials:
     amqps:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
-      host:      (( grab jobs.standalone/0.ips[0] ))
+      host:      (( grab credentials.dnsname ))
       port: 5671
       vhost:     (( grab params.instance_id || "/" ))
-      uris:      (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.tls_port ))
+      uris:      (( cartesian-product "amqps://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.tls_port ))
       uri:       (( grab credentials.protocols.amqps.uris[0] ))
       ssl: true
 <% end -%>
@@ -60,10 +61,10 @@ credentials:
     management:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
-      host:      (( grab jobs.standalone/0.ips[0] ))
+      host:      (( grab credentials.dnsname ))
       port: 15672
       path: "/api"
-      uris:      (( cartesian-product "http://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips ":" credentials.mgmt_port "/api" ))
+      uris:      (( cartesian-product "http://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management.uris[0] ))
       ssl: false
 <% end -%>
@@ -71,10 +72,10 @@ credentials:
     management_tls:
       username:  (( grab meta.username-app ))
       password:  (( grab meta.password-app ))
-      host:      (( grab jobs.standalone/0.ips[0] ))
+      host:      (( grab credentials.dnsname ))
       port: 15671
       path: "/api"
-      uris:      (( cartesian-product "https://" meta.username-app ":" meta.password-app "@" jobs.standalone/0.ips[0] ":" credentials.tls_mgmt_port "/api" ))
+      uris:      (( cartesian-product "https://" meta.username-app ":" meta.password-app "@" credentials.dnsname ":" credentials.tls_mgmt_port "/api" ))
       uri:       (( grab credentials.protocols.management_tls.uris[0] ))
       ssl: true
 <% end -%>

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -56,11 +56,10 @@ variables:
   options:
     ca: (( concat "/" meta.bosh_env "-bosh/" meta.environment "-blacksmith/blacksmith_services_ca" ))
     common_name: (( concat meta.environment "-rabbitmq-standalone.bosh" ))
-
+    alternative_names: [(( concat name ".<%= p("cf.system_domain") %>" ))]
   consumes:
-    alternative_name: 
-      from: rabbitmq-san 
-
+    alternative_name:
+      from: rabbitmq-san
       properties:
         wildcard: true
 <% end -%>
@@ -77,10 +76,9 @@ features:
 instance_groups:
 - name: standalone
   instances: 1
+  azs: (( grab meta.azs ))
   stemcell: default
   vm_type: (( grab meta.size ))
-
-  azs: (( grab meta.azs ))
 
   networks: 
     - name: (( grab meta.net || "rabbitmq-service" ))
@@ -138,7 +136,7 @@ instance_groups:
         ip_addresses: false
 
     custom_provider_definitions:
-      - name: rabbitmq-san  
+      - name: rabbitmq-san
         type: address
       - name: rabbitmq-alias-domain
         type: placeholder
@@ -221,7 +219,7 @@ instance_groups:
         routes:
         - name: (( grab name ))
           uris:
-            - (( concat name ".<%= p("cf.system_domain") %>" ))
+          - (( concat name ".<%= p("cf.system_domain") %>" ))
           registration_interval: 10s
 <% if p("rabbitmq.route_registrar.tls.enabled") == true -%>
           tls_port: 15671
@@ -233,11 +231,11 @@ instance_groups:
     consumes:
       nats:
         from: nats
-        deployment: <%= p("cf.deployment_name") %>
+        deployment: <%= p("cf.deployment_name") -%>
 
       nats-tls:
         from: nats-tls
-        deployment: <%= p("cf.deployment_name") %>
+        deployment: <%= p("cf.deployment_name") -%>
 
   - name:    bpm
     release: bpm
@@ -272,6 +270,7 @@ addons:
           instance_group: nats
           network: (( grab params.cf.core_network ))
           query: _
+
 <% end -%>
 
 releases:
@@ -290,10 +289,10 @@ releases:
     version: latest
 <% end -%>
 <% if p("rabbitmq.autoscale.enabled") -%>
-  - name: loggregator-agent
+  - name:    loggregator-agent
     version: 6.3.4
-    url: https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
-    sha1: 9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+    url:     https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
+    sha1:    9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
   - name: rabbitmq-metrics-emitter
     version: 0.4.1
     url:     https://github.com/starkandwayne/rabbitmq-metrics-emitter-release/releases/download/v0.4.1/rabbitmq-metrics-emitter-0.4.1.tgz


### PR DESCRIPTION
When the application bound to rabbitmq makes a call to rabbitmq service instance using verify_peer_value or equivalent, the connection fails due to the certificate returned having a dns record as a SAN when compared to the call which is made against the IP:

To address this, the logic behind the communication to the service instance was changed to rely on the DNS record consumed by the provided rabbitmq-san. jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml was added a dnsname key which should be populated by the internal .bosh dns record.

https://github.com/blacksmith-community/blacksmith/pull/39/files added `params.hostname`

With the params.hostname value available to us, jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/credentials.yml and jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/credentials.yml was updated to use credentials.dnsname as the host instead of the ip to all the keys the application itself uses to communicate with the service broker.

Using the router’s log stream, an issue was identified with the provided certificates:

```
router/ded3f118-f4c5-4755-b055-35b837065078: stdout | 2022/12/07 18:36:59 http: proxy error: x509: certificate is valid for *.standalone.blacksmith.rabbitmq-single-node-4b2f5ad1-a2de-4eaa-85c6-dd717140922c.bosh, not rabbitmq-single-node-4b2f5ad1-a2de-4eaa-85c6-dd717140922c.system.codex2.starkandwayne.com
```

To address this an additional `alternative_names` was added to credhub’s properties for each of the plan types.
