### PR TITLE
Update cf deployment

### DIFF
--- a/ci/manifest.yml
+++ b/ci/manifest.yml
@@ -54,7 +54,7 @@ update:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 releases:

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,8 +1,8 @@
-erlang/otp_src_24.3.4.4.tar.gz:
-  size: 107798120
-  object_id: 7478f64f-faa5-4580-6aa6-e21b5fd770b5
-  sha: sha256:86dddc0de486acc320ed7557f12033af0b5045205290ee4926aa931b3d8b3ab2
-rabbitmq/rabbitmq-server-generic-unix-3.9.22.tar.xz:
-  size: 12761888
-  object_id: 68f609d3-cb43-4085-602a-cdbdbf1eb414
-  sha: sha256:acf2fa033226ba389333562ec1684dfcc18a53bdf06162f29d3898c85b730be6
+erlang/otp_src_25.3.2.2.tar.gz:
+  size: 103844480
+  object_id: bdd3f73b-0f50-456f-4954-ec568354ca96
+  sha: sha256:83a36f3d90deef36adb615bbfb46cd327f0b76b7668e1f7f253fd66b4ae24518
+rabbitmq/rabbitmq-server-generic-unix-3.12.0.tar.xz:
+  size: 15500200
+  object_id: 94605c09-7f9f-41f8-474a-614af4b8cc23
+  sha: sha256:dd36af31868d620e1492452657dd115b33ff4bd6017790134becd3c3ddfcafbb

--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -76,6 +76,10 @@ properties:
 
   cf.password:
     description: The admin password for cloudfoundry
+  
+  cf.nats_tls_only:
+    description: Allow only tls communication with nats (since cf-deployment 17.0.0)
+    default: false
 
   loggregator.tls.ca_cert:
     description: The CA Certificate for loggregator

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -308,7 +308,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -284,22 +284,26 @@ releases:
   - name: rabbitmq-forge
     version: latest
 <% if p("rabbitmq.route_registrar.enabled") -%>
-  - name: routing
-    version: latest
+  - name: "routing"
+    version: "0.266.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.266.0"
+    sha1: "d57ae8fe0d0d8a9b040cea254a782d1d5e8fa2e3"
 <% end -%>
 <% if p("rabbitmq.route_registrar.enabled") || p("rabbitmq.autoscale.enabled") -%>
-  - name: bpm
-    version: 1.1.12
-    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.12
-    sha1: 502e9446fa34accaf122ad2b28b6ffa543d5bbca
-  - name: bosh-dns-aliases
-    version: latest
+  - name: "bpm"
+    version: "1.2.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.1"
+    sha1: "36299a55c00d28cfe54bbb4772ca617f52d76adb"
+  - name: "bosh-dns-aliases"
+    version: "0.0.4"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4"
+    sha1: "55b3dced813ff9ed92a05cda02156e4b5604b273"
 <% end -%>
 <% if p("rabbitmq.autoscale.enabled") -%>
-  - name:    loggregator-agent
-    version: 6.3.4
-    url:     https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
-    sha1:    9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+  - name: "loggregator-agent"
+    version: "7.2.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.2.1"
+    sha1: "623e45f6c19a68d01c313a9a1a504dabc39ac1cf"
   - name: rabbitmq-metrics-emitter
     version: 0.4.1
     url:     https://github.com/starkandwayne/rabbitmq-metrics-emitter-release/releases/download/v0.4.1/rabbitmq-metrics-emitter-0.4.1.tgz

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -230,6 +230,7 @@ instance_groups:
 <% end -%>
 
     consumes:
+<% if p("cf.nats_tls_only") == false -%>
       nats:
         from: nats
         deployment: <%= p("cf.deployment_name") -%>
@@ -237,6 +238,11 @@ instance_groups:
       nats-tls:
         from: nats-tls
         deployment: <%= p("cf.deployment_name") -%>
+<% else -%>
+      nats-tls:
+        from: nats-tls
+        deployment: <%= p("cf.deployment_name") -%>
+<% end -%>
 
   - name:    bpm
     release: bpm

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -307,7 +307,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -229,6 +229,7 @@ instance_groups:
 <% end -%>
 
     consumes:
+<% if p("cf.nats_tls_only") == false -%>
       nats:
         from: nats
         deployment: <%= p("cf.deployment_name") -%>
@@ -236,6 +237,11 @@ instance_groups:
       nats-tls:
         from: nats-tls
         deployment: <%= p("cf.deployment_name") -%>
+<% else -%>
+      nats-tls:
+        from: nats-tls
+        deployment: <%= p("cf.deployment_name") -%>
+<% end -%>
 
   - name:    bpm
     release: bpm

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -283,22 +283,26 @@ releases:
   - name: rabbitmq-forge
     version: latest
 <% if p("rabbitmq.route_registrar.enabled") -%>
-  - name: routing
-    version: latest
+  - name: "routing"
+    version: "0.266.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.266.0"
+    sha1: "d57ae8fe0d0d8a9b040cea254a782d1d5e8fa2e3"
 <% end -%>
 <% if p("rabbitmq.route_registrar.enabled") || p("rabbitmq.autoscale.enabled") -%>
-  - name: bpm
-    version: 1.1.12
-    url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.12
-    sha1: 502e9446fa34accaf122ad2b28b6ffa543d5bbca
-  - name: bosh-dns-aliases
-    version: latest
+  - name: "bpm"
+    version: "1.2.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.1"
+    sha1: "36299a55c00d28cfe54bbb4772ca617f52d76adb"
+  - name: "bosh-dns-aliases"
+    version: "0.0.4"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.4"
+    sha1: "55b3dced813ff9ed92a05cda02156e4b5604b273"
 <% end -%>
 <% if p("rabbitmq.autoscale.enabled") -%>
-  - name:    loggregator-agent
-    version: 6.3.4
-    url:     https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=6.3.4
-    sha1:    9dd3ad00fb49bebd8290fad8ce7b2e4992dac31f
+  - name: "loggregator-agent"
+    version: "7.2.1"
+    url: "https://bosh.io/d/github.com/cloudfoundry/loggregator-agent-release?v=7.2.1"
+    sha1: "623e45f6c19a68d01c313a9a1a504dabc39ac1cf"
   - name: rabbitmq-metrics-emitter
     version: 0.4.1
     url:     https://github.com/starkandwayne/rabbitmq-metrics-emitter-release/releases/download/v0.4.1/rabbitmq-metrics-emitter-0.4.1.tgz

--- a/packages/erlang/packaging
+++ b/packages/erlang/packaging
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-VERSION=24.3.4.4
+VERSION=25.3.2.2
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
 tar xfv erlang/otp_src_${VERSION}.tar.gz

--- a/packages/rabbitmq/packaging
+++ b/packages/rabbitmq/packaging
@@ -2,7 +2,7 @@
 
 set -ex
 
-VERSION=3.9.22
+VERSION=3.12.0
 
 tar -xf $BOSH_COMPILE_TARGET/rabbitmq/rabbitmq-server-generic-unix-${VERSION}.tar.xz
 


### PR DESCRIPTION
Changes include:

* the ability to use the parameter   `cf: nats_tls_only: true` which allows for required tls communication with nats on newer cf-deployments
* defaults stemcell to ubuntu-jammy
* updates rabbitmq to 3.12
* updates erlang to 25.3.2.2
* updates included bosh-releases