### PR TITLE
Randomly generate erlang cookie for service instances

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/init
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/init
@@ -10,4 +10,6 @@ safe gen $CREDENTIALS/rabbitmq/monitoring password
 safe gen $CREDENTIALS/rabbitmq/app username
 safe gen $CREDENTIALS/rabbitmq/app password
 
+safe gen $CREDENTIALS/rabbitmq/erlang cookie
+
 exit 0

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -11,6 +11,7 @@ meta:
   password-app: (( vault $CREDENTIALS "/rabbitmq/app:password" ))
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
+  erlang_cookie: (( vault $CREDENTIALS "/rabbitmq/erlang:cookie" ))
 
 <% if p("rabbitmq.autoscale.enabled") -%>
   cf:
@@ -91,6 +92,8 @@ instance_groups:
     release: rabbitmq-forge
 
     properties:
+      erlang:
+        cookie: (( grab meta.erlang_cookie ))
       rabbitmq:
         plan: cluster
         vhost: (( grab meta.params.instance_id || "/" ))

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/init
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/init
@@ -10,4 +10,6 @@ safe gen $CREDENTIALS/rabbitmq/monitoring password
 safe gen $CREDENTIALS/rabbitmq/app username
 safe gen $CREDENTIALS/rabbitmq/app password
 
+safe gen $CREDENTIALS/rabbitmq/erlang cookie
+
 exit 0

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -10,6 +10,7 @@ meta:
   password-app: (( vault $CREDENTIALS "/rabbitmq/app:password" ))
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
+  erlang_cookie: (( vault $CREDENTIALS "/rabbitmq/erlang:cookie" ))
 
 <% if p("rabbitmq.autoscale.enabled") -%>
   cf:
@@ -90,6 +91,8 @@ instance_groups:
     release: rabbitmq-forge
 
     properties:
+      erlang:
+        cookie: (( grab meta.erlang_cookie ))
       rabbitmq:
         plan: standalone
         vhost: (( grab meta.params.instance_id || "/" ))


### PR DESCRIPTION
Currently when a new service instance is created, it uses "insecure-erlang-cookie" as its erlang cookie value. This fix randomly generates a cookie each time a service is created