### PR TITLE
Update RabbitMQ versions

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+# Improvements
+
+* Updates RabbitMQ to version 3.13.3
+
+* Update Erlang/OTP to version 26.2.5
+

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,8 +1,8 @@
-erlang/otp_src_25.3.2.2.tar.gz:
-  size: 103844480
-  object_id: bdd3f73b-0f50-456f-4954-ec568354ca96
-  sha: sha256:83a36f3d90deef36adb615bbfb46cd327f0b76b7668e1f7f253fd66b4ae24518
-rabbitmq/rabbitmq-server-generic-unix-3.12.0.tar.xz:
-  size: 15500200
-  object_id: 94605c09-7f9f-41f8-474a-614af4b8cc23
-  sha: sha256:dd36af31868d620e1492452657dd115b33ff4bd6017790134becd3c3ddfcafbb
+erlang/otp_src_26.2.5.tar.gz:
+  size: 106139168
+  object_id: 1fbc926a-59d5-4b27-5de3-a97d132319f2
+  sha: sha256:de155c4ad9baab2b9e6c96dbd03bf955575a04dd6feee9c08758beb28484c9f6
+rabbitmq/rabbitmq-server-generic-unix-3.13.3.tar.xz:
+  size: 16498020
+  object_id: 2d5b6eb2-8f62-4452-66fa-345f0dda73ac
+  sha: sha256:ebd7ef9625c5beb1d16d774467489b96b6b637c2fdf1026b5e90a6d56159b4c5

--- a/packages/erlang/packaging
+++ b/packages/erlang/packaging
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-VERSION=25.3.2.2
+VERSION=26.2.5
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
 tar xfv erlang/otp_src_${VERSION}.tar.gz

--- a/packages/rabbitmq/packaging
+++ b/packages/rabbitmq/packaging
@@ -2,7 +2,7 @@
 
 set -ex
 
-VERSION=3.12.0
+VERSION=3.13.3
 
 tar -xf $BOSH_COMPILE_TARGET/rabbitmq/rabbitmq-server-generic-unix-${VERSION}.tar.xz
 


### PR DESCRIPTION
# Improvements

* Updates RabbitMQ to version 3.13.3
* Update Erlang/OTP to version 26.2.5