### PR TITLE
Add support for enabling custom RabbitMQ plugins

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/spec
+++ b/jobs/rabbitmq-blacksmith-plans/spec
@@ -57,6 +57,10 @@ properties:
 
   bosh_env:
     description: The environment name of the bosh deployment if different from cloudfoundry (defaults to environment)
+  
+  plugins:
+    description: List of RabbitMQ plugins to enable
+    default: []
 
   cf.exodus_path:
     description: The vault path pointing to the cf deployment

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -12,6 +12,7 @@ meta:
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
   erlang_cookie: (( vault $CREDENTIALS "/rabbitmq/erlang:cookie" ))
+  plugins: <%= p('plugins') %>
 
 <% if p("rabbitmq.autoscale.enabled") -%>
   cf:
@@ -92,6 +93,7 @@ instance_groups:
     release: rabbitmq-forge
 
     properties:
+      plugins: (( grab meta.plugins ))
       erlang:
         cookie: (( grab meta.erlang_cookie ))
       rabbitmq:

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -11,6 +11,7 @@ meta:
   environment: <%= p('environment') %>
   bosh_env: <%= p('bosh_env') %>
   erlang_cookie: (( vault $CREDENTIALS "/rabbitmq/erlang:cookie" ))
+  plugins: <%= p('plugins') %>
 
 <% if p("rabbitmq.autoscale.enabled") -%>
   cf:
@@ -91,6 +92,7 @@ instance_groups:
     release: rabbitmq-forge
 
     properties:
+      plugins: (( grab meta.plugins ))
       erlang:
         cookie: (( grab meta.erlang_cookie ))
       rabbitmq:

--- a/jobs/rabbitmq/templates/bin/ctl
+++ b/jobs/rabbitmq/templates/bin/ctl
@@ -15,9 +15,23 @@ case $1 in
     chown vcap:vcap /var/vcap/store/rabbitmq/RABBITMQ_VERSION \
       /var/vcap/store/rabbitmq/ERLANG_VERSION_FULL
 
+    PLUGINS=""
     <% if p('management') -%>
-    rabbitmq-plugins enable --offline rabbitmq_management >>$LOG_DIR/rabbitmq.log 2>&1
+    PLUGINS="rabbitmq_management"
     <% end %>
+
+    # Add additional plugins specified in params
+    <% if_p('plugins') do |additional_plugins| %>
+    PLUGINS="$PLUGINS <%= additional_plugins.join(' ') %>"
+    <% end %>
+
+    # Enable additional plugins specified in params
+    if [ ! -z "$PLUGINS" ]; then
+      echo "Enabling plugins: $PLUGINS" >>$LOG_DIR/rabbitmq.log 2>&1
+      rabbitmq-plugins enable --offline $PLUGINS >>$LOG_DIR/rabbitmq.log 2>&1
+    else
+      echo "No plugins specified to enable" >>$LOG_DIR/rabbitmq.log 2>&1
+    fi
 
     exec chpst -u vcap:vcap rabbitmq-server >>$LOG_DIR/rabbitmq.log 2>&1
     ;;

--- a/jobs/rabbitmq/templates/env.rb
+++ b/jobs/rabbitmq/templates/env.rb
@@ -23,7 +23,7 @@ export RABBITMQ_NODENAME="rabbit@<%= spec.id %>.<%= spec.name %>.<%= p('rabbitmq
 export RABBITMQ_PID_FILE="${RUN_DIR}/rabbitmq.pid"
 export RABBITMQ_USE_LONGNAME="true"
 export RABBITMQ_VHOST="<%= p('rabbitmq.vhost') %>"
-export RABBITMQ_EVAL_TIMEOUT="60"
+export RABBITMQ_EVAL_TIMEOUT="90"
 
 # Erlang
 export EPMD_PID_FILE="${RUN_DIR}/epmd.pid"


### PR DESCRIPTION
- Introduced a `plugins` property in `rabbitmq-blacksmith-plans/spec` for specifying a list of RabbitMQ plugins to enable.
- Updated cluster and standalone manifest templates to include the `plugins` property.
- Modified `ctl` script to handle the enabling of specified plugins during the startup process.
- Adjusted `RABBITMQ_EVAL_TIMEOUT` in `env.rb` from 60 to 90 seconds.