### PR TITLE
declared plugins property in rabbitmq/spec file to enable plugins

### DIFF
--- a/jobs/rabbitmq/spec
+++ b/jobs/rabbitmq/spec
@@ -49,6 +49,8 @@ properties:
     default: rabbitmq-service
   rabbitmq.plan:
     description: The plan type (standalone/cluster) currently in use
+  plugins:
+    default: []
 
   rabbitmq.admin.user:
     description: "Rabbitmq admin username"


### PR DESCRIPTION
Rabbitmq-forge 1.2.5 couldn't fetch plugins from the manifest because the plugins property wasn't declared in jobs/rabbitmq/spec.