### PR TITLE
update rmq forge manifest for log-cache

### DIFF
--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -152,29 +152,46 @@ instance_groups:
   - name:    bpm
     release: bpm
 <% end -%>
-
-  - name: loggregator_agent
+  - name: loggr-syslog-agent
     release: loggregator-agent
-
+    
     consumes:
-      doppler:
-        from: doppler
-        deployment: (( grab meta.cf.deployment_name ))
+      binding_cache:
+        from: binding_cache
+        deployment: <%= p("cf.deployment_name") -%>
 
     properties:
-      loggregator:
+      port: 3460
+      drain_ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+      tls:
+        ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+        cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+        key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+      cache:
         tls:
-          ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
-          agent:
-            cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
-            key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
-
+          ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/syslog_agent_api.ca" ))
+          cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/syslog_agent_api.crt" ))
+          key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/syslog_agent_api.key" ))
+          cn: binding-cache
       metrics:
-        server_name: (( concat meta.environment "-rabbitmq-metrics-emitter" ))
-        ca_cert: (( file "/var/vcap/jobs/blacksmith/config/tls/blacksmith_services_ca" ))
-        cert:    ((rabbitmq_metrics_emitter_crt.certificate))
-        key:     ((rabbitmq_metrics_emitter_crt.private_key))
+        ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/syslog_agent_metrics.ca" ))
+        cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/syslog_agent_metrics.crt" ))
+        key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/syslog_agent_metrics.key" ))
+        server_name: syslog_agent_metrics
 
+  - name: loggr-forwarder-agent
+    release: loggregator-agent
+    properties:
+      tls:
+        ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.ca" ))
+        cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.crt" ))
+        key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/loggregator.key" ))
+      metrics:
+        ca_cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/forwarder_agent_metrics.ca" ))
+        cert: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/forwarder_agent_metrics.crt" ))
+        key: (( file "/var/vcap/jobs/rabbitmq-blacksmith-plans/tls/forwarder_agent_metrics.key" ))
+        server_name: forwarder_agent_metrics
+        
   - name: rabbitmq-metrics-emitter
     release: rabbitmq-metrics-emitter
 
@@ -282,6 +299,26 @@ addons:
           instance_group: nats
           network: (( grab params.cf.core_network ))
           query: _
+
+<% if p("rabbitmq.autoscale.enabled") -%>
+      - domain: log-cache.service.cf.internal
+
+        targets:
+        - deployment: (( grab meta.cf.deployment_name ))
+          domain: bosh
+          instance_group: log-cache
+          network: (( grab params.cf.core_network ))
+          query: '*'
+
+      - domain: _.log-cache.service.cf.internal 
+      
+        targets:
+        - deployment: (( grab meta.cf.deployment_name ))
+          domain: bosh
+          instance_group: log-cache
+          network: (( grab params.cf.core_network ))
+          query: _
+<% end -%>
 
 <% end -%>
 

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -155,9 +155,8 @@ instance_groups:
     release: loggregator-agent
     
     consumes:
-      log-cache:
-        from: log-cache
-        alias: binding_cache
+      binding_cache:
+        from: binding_cache
         deployment: <%= p("cf.deployment_name") -%>
 
     properties:
@@ -299,6 +298,26 @@ addons:
           instance_group: nats
           network: (( grab params.cf.core_network ))
           query: _
+
+<% if p("rabbitmq.autoscale.enabled") -%>
+      - domain: log-cache.service.cf.internal
+
+        targets:
+        - deployment: (( grab meta.cf.deployment_name ))
+          domain: bosh
+          instance_group: log-cache
+          network: (( grab params.cf.core_network ))
+          query: '*'
+
+      - domain: _.log-cache.service.cf.internal 
+      
+        targets:
+        - deployment: (( grab meta.cf.deployment_name ))
+          domain: bosh
+          instance_group: log-cache
+          network: (( grab params.cf.core_network ))
+          query: _
+<% end -%>
 
 <% end -%>
 


### PR DESCRIPTION
- Added new properties to the standalone and cluster plans to support log-cache integration
- Introduced bosh-dns alias for log-cache