### PR TITLE
Upgrade RabbitMQ 3.13.6 → 4.2.7 and Erlang → 26.2.5.21

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,7 +2,7 @@ erlang/otp_src_26.2.5.21.tar.gz:
   size: 106347158
   object_id: b7707f30-4fcc-4208-71a5-da5ebc3db2c6
   sha: sha256:e1fde86f4e2874d4c136221a34753b5b785d762b910fb3fb35a23a6a7faf0a64
-rabbitmq/rabbitmq-server-generic-unix-3.13.6.tar.xz:
-  size: 16572992
-  object_id: ee138689-d5cb-4252-5515-519fbbfdff99
-  sha: sha256:7bfc742e3d227e8a2b1ea2a0b5ef3ba4b6a7987d5e220e0fbf0919d29b6ed43c
+rabbitmq/rabbitmq-server-generic-unix-4.2.7.tar.xz:
+  size: 23430428
+  object_id: 2c1e749b-69a4-4eed-7d28-398e89016f7a
+  sha: sha256:35a1b1699d8369e0c63d31676978ffa98d171855e21d662170ae91dcfc3557b1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-erlang/otp_src_26.2.5.14.tar.gz:
-  size: 106315999
-  object_id: 3d86fe56-acc2-4c52-653d-5638b60ffef5
-  sha: sha256:39f5e25709820606ab11c867285a2132ac4b2999827af0071a1fb2ef1589ad9a
+erlang/otp_src_26.2.5.21.tar.gz:
+  size: 106347158
+  object_id: b7707f30-4fcc-4208-71a5-da5ebc3db2c6
+  sha: sha256:e1fde86f4e2874d4c136221a34753b5b785d762b910fb3fb35a23a6a7faf0a64
 rabbitmq/rabbitmq-server-generic-unix-3.13.6.tar.xz:
   size: 16572992
   object_id: ee138689-d5cb-4252-5515-519fbbfdff99

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -359,7 +359,7 @@ stemcells:
 
 update:
   canaries: 1
-  max_in_flight: 10
+  max_in_flight: 1
   canary_watch_time: 1000-30000
   update_watch_time: 1000-30000
 

--- a/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/rabbitmq-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -358,7 +358,7 @@ stemcells:
 
 update:
   canaries: 1
-  max_in_flight: 10
+  max_in_flight: 1
   canary_watch_time: 1000-30000
   update_watch_time: 1000-30000
 

--- a/jobs/rabbitmq/templates/config/advanced.config.erb
+++ b/jobs/rabbitmq/templates/config/advanced.config.erb
@@ -1,10 +1,6 @@
 # TODO: Convert this file to the new formate merging into rabbitmq.conf
 [
   {rabbit, [
-    <% servers = link('rabbitmq-servers').instances -%>
-    <% if servers.size > 1 -%>
-    {cluster_nodes, {[<%= servers.map { |n| "#{n.name}@#{n.id.tr("-","")}"}.join(',') %>], disc}},
-    <% end -%>
     {loopback_users, []}
   ]}
 ].

--- a/packages/erlang/packaging
+++ b/packages/erlang/packaging
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-VERSION=26.2.5.14
+VERSION=26.2.5.21
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
 tar xfv erlang/otp_src_${VERSION}.tar.gz

--- a/packages/rabbitmq/packaging
+++ b/packages/rabbitmq/packaging
@@ -2,7 +2,7 @@
 
 set -ex
 
-VERSION=3.13.6
+VERSION=4.2.7
 
 tar -xf $BOSH_COMPILE_TARGET/rabbitmq/rabbitmq-server-generic-unix-${VERSION}.tar.xz
 


### PR DESCRIPTION
## What

Upgrade the forge's bundled server + runtime and align the rolling-update config:

- **RabbitMQ** `3.13.6 → 4.2.7` (crosses the 3.13 → 4.x boundary; directly supported single-hop rolling upgrade)
- **Erlang/OTP** `26.2.5.14 → 26.2.5.21` (security patch within the 26.2.x line, in RabbitMQ 4.2's supported Erlang range)
- Remove the Mnesia-era `{cluster_nodes, …, disc}` block from `advanced.config.erb` — a removed concept under 4.x; peer discovery is already handled by `cluster_formation.classic_config` in `rabbitmq.conf`
- Set the cluster/standalone plan `update.max_in_flight` `10 → 1` — serial rolling update, so a 3-node cluster doesn't take the other two nodes down together after the canary

The forge stays **Mnesia-default** (no `khepri_db` enablement); existing instances follow the single-hop 3.13 → 4.2 rolling path.

## Blob verification

| Blob | sha256 | signature |
|---|---|---|
| `otp_src_26.2.5.21.tar.gz` | matches upstream `OTP-26.2.5.21/SHA256.txt` | — |
| `rabbitmq-server-generic-unix-4.2.7.tar.xz` | verified | GPG **good signature**, RabbitMQ Release Signing Key `0A9AF2115F4687BD29803A206B73A36E6026DFCA` |

Both blobs are uploaded to the release blobstore (`object_id`s present in `config/blobs.yml`).

## Validation

- `bosh create-release` builds cleanly with the bumped packages.
- Deployed via Blacksmith and **rolling-upgraded in place** on both plans (three-node cluster + standalone): all nodes rejoin, cluster health clean (0 partitions, no alarms), AMQP publish/consume roundtrip passes, and topology (vhosts/users/permissions/policies), enabled plugins, and binding-credential shape are unchanged vs. the 3.13.6 baseline. Running node reports RabbitMQ 4.2.7 / Erlang 26.2.5.21.

The final `Release 1.5.0` cut is not part of this PR.
